### PR TITLE
PIP Requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 - To install Pip, see [their instructions](http://www.pip-installer.org/en/latest/installing.html).
 
 ```sh
-pip install django-openid
+pip install -r requirements.txt
 ```
 
 ```sh

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Django==1.5.1
+python-openid==2.2.5
+django-openid-auth==0.5


### PR DESCRIPTION
Simplified pip install using a requirements.txt. This will make it easier to add dependencies going forward while keeping the installation process relatively simple. Also added missing dependency _python-openid_ required by _django-openid_.
