### PR TITLE
feature/travis-config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: python
+python:
+  - "2.7"
+
+# set environment variables
+env:
+    - DJANGO_SETTINGS_MODULE="harvardcards.settings.dev"
+
+# command to install dependencies
+install: "pip install -r requirements.txt --use-mirrors"
+
+# command to run tests
+script: nosetests


### PR DESCRIPTION
This PR adds a config file so that we can hook into the [travis continuous integration server](https://travis-ci.org/) via github's service hooks. The config just sets up the DJANGO environment variables, tells it how to install the necessary dependencies, and how to execute the test script.
