### PR TITLE
feature/vagrant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 .svn
 *.pyc
 flash.db
+django-server.log
+.idea
+.vagrant
 /harvardcards/modules/flashcard-exporter/cache/*
 /harvardcards/apps/flash/uploads/*

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,119 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  # All Vagrant configuration is done here. The most common configuration
+  # options are documented and commented below. For a complete reference,
+  # please see the online documentation at vagrantup.com.
+
+  # Every Vagrant virtual environment requires a box to build off of.
+  #config.vm.box = "base"
+  config.vm.box = "precise32"
+
+  # The url from where the 'config.vm.box' box will be fetched if it
+  # doesn't already exist on the user's system.
+  # config.vm.box_url = "http://domain.com/path/to/above.box"
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  config.vm.network :forwarded_port, guest: 8000, host: 8080
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network :private_network, ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network :public_network
+
+  # If true, then any SSH connections made will enable agent forwarding.
+  # Default value: false
+  # config.ssh.forward_agent = true
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  # config.vm.synced_folder "HarvardCards", "/home/vagrant/HarvardCards", create: true
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  # config.vm.provider :virtualbox do |vb|
+  #   # Don't boot with headless mode
+  #   vb.gui = true
+  #
+  #   # Use VBoxManage to customize the VM. For example to change memory:
+  #   vb.customize ["modifyvm", :id, "--memory", "1024"]
+  # end
+  #
+  # View the documentation for the provider you're using for more
+  # information on available options.
+
+  # Enable provisioning with Puppet stand alone.  Puppet manifests
+  # are contained in a directory path relative to this Vagrantfile.
+  # You will need to create the manifests directory and a manifest in
+  # the file base.pp in the manifests_path directory.
+  #
+  # An example Puppet manifest to provision the message of the day:
+  #
+  # # group { "puppet":
+  # #   ensure => "present",
+  # # }
+  # #
+  # # File { owner => 0, group => 0, mode => 0644 }
+  # #
+  # # file { '/etc/motd':
+  # #   content => "Welcome to your Vagrant-built virtual machine!
+  # #               Managed by Puppet.\n"
+  # # }
+  #
+  config.vm.provision :puppet do |puppet|
+    puppet.manifests_path = "manifests"
+    puppet.manifest_file  = "site.pp"
+  end
+
+  # Enable provisioning with chef solo, specifying a cookbooks path, roles
+  # path, and data_bags path (all relative to this Vagrantfile), and adding
+  # some recipes and/or roles.
+  #
+  # config.vm.provision :chef_solo do |chef|
+  #   chef.cookbooks_path = "../my-recipes/cookbooks"
+  #   chef.roles_path = "../my-recipes/roles"
+  #   chef.data_bags_path = "../my-recipes/data_bags"
+  #   chef.add_recipe "mysql"
+  #   chef.add_role "web"
+  #
+  #   # You may also specify custom JSON attributes:
+  #   chef.json = { :mysql_password => "foo" }
+  # end
+
+  # Enable provisioning with chef server, specifying the chef server URL,
+  # and the path to the validation key (relative to this Vagrantfile).
+  #
+  # The Opscode Platform uses HTTPS. Substitute your organization for
+  # ORGNAME in the URL and validation key.
+  #
+  # If you have your own Chef Server, use the appropriate URL, which may be
+  # HTTP instead of HTTPS depending on your configuration. Also change the
+  # validation key to validation.pem.
+  #
+  # config.vm.provision :chef_client do |chef|
+  #   chef.chef_server_url = "https://api.opscode.com/organizations/ORGNAME"
+  #   chef.validation_key_path = "ORGNAME-validator.pem"
+  # end
+  #
+  # If you're using the Opscode platform, your validator client is
+  # ORGNAME-validator, replacing ORGNAME with your organization name.
+  #
+  # If you have your own Chef Server, the default validation client name is
+  # chef-validator, unless you changed the configuration.
+  #
+  #   chef.validation_client_name = "ORGNAME-validator"
+end

--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -1,0 +1,74 @@
+Exec {
+	path => "/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin",
+}
+
+include init
+
+class init {
+	group { "puppet":
+		ensure => "present",
+	}
+	
+	exec { "update-apt":
+		command => "sudo apt-get update",
+	}
+	
+	package { 'git':
+		ensure => latest,
+		require => Exec['update-apt'],
+	}
+
+	# install some dependencies
+	package {
+		["python", "python-dev", "python-pip", "python-setuptools"]:
+		ensure => installed,
+		require => Exec['update-apt']
+	}
+}
+
+class djangoapp {
+	$PROJ_DIR = "/vagrant"
+
+	# install dependencies needed for Pillow (python imaging module)
+	# https://pypi.python.org/pypi/Pillow/
+	# http://pillow.readthedocs.org/
+	package { 
+		['libtiff4-dev', 'libjpeg8-dev', 'zlib1g-dev',  'libfreetype6-dev', 'liblcms2-dev', 'tcl8.5-dev', 'tk8.5-dev', 'python-tk']:
+		ensure => installed,
+		require => Exec['update-apt']
+	}
+
+	# install project dependencies
+	exec { "pip-install-requirements":
+		command => "sudo /usr/bin/pip install -r $PROJ_DIR/requirements.txt",
+		tries => 2,
+		timeout => 600,
+		require => Package['python-pip', 'python-dev'],
+		logoutput => true,
+	}
+
+	# syncdb
+	exec { "django-syncdb":
+		command => "python manage.py syncdb --noinput",
+		cwd => "$PROJ_DIR",
+		require => Exec['pip-install-requirements'],
+		logoutput => true,
+	}
+
+	# setup super user
+	exec { "django-setup-superuser":
+		command => 'echo "from django.contrib.auth.models import User; User.objects.create_superuser(\'admin\', \'admin@example.com\', \'admin\')" | ./manage.py shell',
+		cwd => "$PROJ_DIR",
+		require => Exec['django-syncdb']
+	}
+
+	# start server?
+	exec { "django-runserver":
+		command => "python manage.py runserver 0.0.0.0:8000 >django-server.log 2>&1 &",
+		cwd => "$PROJ_DIR",
+		require => Exec['django-syncdb'],
+		logoutput => true,	
+	}
+}
+
+include djangoapp


### PR DESCRIPTION
Adds Vagrantfile and puppet manifests so that a user can easily setup a development environment with a running django server and all the necessary dependencies for both the system and application. Getting the code and development environment should be as easy as this:

``` sh
git clone https://github.com/Harvard-ATG/HarvardCards.git 
cd HarvardCards
vagrant up
```

The django server will be running on `http://localhost:8080/`. If any changes are made to the python `requirements.txt` or puppet manifest `manifests/site.pp`, just do a `vagrant provision`.

This was adapted from [django-vagrant](https://github.com/Harvard-ATG/django-vagrant).

Potential improvements for future sprints:
- Setup MySQL and settings config so Django can use that instead of SQLite. 
- Setup Apache or Nginx as the server instead of using the built-in Django server.

@jazahn can you review?
