### PR TITLE
feature/sharedhosting-mysql

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ django-server.log
 .vagrant
 /harvardcards/modules/flashcard-exporter/cache/*
 /harvardcards/apps/flash/uploads/*
+/config/my.cnf

--- a/config/my.cnf.example
+++ b/config/my.cnf.example
@@ -1,0 +1,7 @@
+[client]
+database = flashdb
+user = flashuser
+password = flashpass
+host = localhost
+port = 3306
+default-character-set = utf8

--- a/harvardcards/settings/dev-mysql.py
+++ b/harvardcards/settings/dev-mysql.py
@@ -1,14 +1,19 @@
 from harvardcards.settings.common import *
 
+import os
+
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.mysql', # Add 'postgresql_psycopg2', 'mysql', 'sqlite3' or 'oracle'.
-        'NAME': 'flashdb',    # Or path to database file if using sqlite3.
+		'OPTIONS': {
+			'read_default_file': os.path.join(ROOT_DIR, 'config', 'my.cnf'),
+		},
+        #'NAME': 'flashdb',    # Or path to database file if using sqlite3.
         # The following settings are not used with sqlite3:
-        'USER': 'flashuser',
-        'PASSWORD': 'flashpass',
-        'HOST': 'localhost',                      # Empty for localhost through domain sockets or '127.0.0.1' for localhost through TCP.
-        'PORT': '3306',                      # Set to empty string for default.
+        #'USER': 'flashuser',
+        #'PASSWORD': 'flashpass',
+        #'HOST': 'localhost',                      # Empty for localhost through domain sockets or '127.0.0.1' for localhost through TCP.
+        #'PORT': '3306',                      # Set to empty string for default.
     }
 }
 

--- a/harvardcards/settings/sharedhosting.py
+++ b/harvardcards/settings/sharedhosting.py
@@ -8,12 +8,16 @@ import os
 
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.sqlite3', # Add 'postgresql_psycopg2', 'mysql', 'sqlite3' or 'oracle'.
-        'NAME': os.path.join(ROOT_DIR, 'flash.db'),
+        'ENGINE': 'django.db.backends.mysql', # Add 'postgresql_psycopg2', 'mysql', 'sqlite3' or 'oracle'.
+		'OPTIONS': {
+			'read_default_file': os.path.join(ROOT_DIR, 'config', 'my.cnf'),
+		},
+        #'ENGINE': 'django.db.backends.sqlite3', # Add 'postgresql_psycopg2', 'mysql', 'sqlite3' or 'oracle'.
+        #'NAME': os.path.join(ROOT_DIR, 'flash.db'),
         # The following settings are not used with sqlite3:
-        'USER': '',
-        'PASSWORD': '',
-        'HOST': '',                      # Empty for localhost through domain sockets or '127.0.0.1' for localhost through TCP.
-        'PORT': '',                      # Set to empty string for default.
+        #'USER': '',
+        #'PASSWORD': '',
+        #'HOST': '',                      # Empty for localhost through domain sockets or '127.0.0.1' for localhost through TCP.
+        #'PORT': '',                      # Set to empty string for default.
     }
 }


### PR DESCRIPTION
This PR modifies the shared hosting settings to use mysql. The sharedhosting settings will look for the username, password, host and other database configuration settings in `config/my.cnf` which is the [MySQL options file](https://dev.mysql.com/doc/refman/5.1/en/option-files.html). That file is ignored by git.
