### PR TITLE
feature/rename-add-course

### DIFF
--- a/harvardcards/templates/_collection_nav.html
+++ b/harvardcards/templates/_collection_nav.html
@@ -1,7 +1,7 @@
 <div id="navigation">
     {% if not collection %}
         {% if user.is_authenticated %}
-            <a href="{% url 'collectionCreate' %}" id="addAcourse">Add a course</a>
+            <a href="{% url 'collectionCreate' %}" id="addAcourse">Add Collection</a>
         {% endif %}
 	{% endif %}
     <nav class="desktopNav" data-set="mobileNav">


### PR DESCRIPTION
This PR renames the "Add a Course" button to "Add Collection" because it doesn't make sense in Canvas. 

When you "Add a Course," you're really just adding a new collection, which is defined as a set of decks grouped together. An instructor can add as many collections as they want, so it no longer makes sense to maintain the 1:1 course:collection terminology. There was some discussion about the exact button text to make it clearer to users who may not be familiar with the collection > deck > card hierarchy that our tool uses. 

@jazahn Review?

---

[FLASH-152](https://jira.huit.harvard.edu/browse/FLASH-152)
