### PR TITLE
feature/fix-collection-nav

### DIFF
--- a/harvardcards/apps/flash/views/collection.py
+++ b/harvardcards/apps/flash/views/collection.py
@@ -1,19 +1,18 @@
 import datetime, base64
 
-from django.http import HttpResponse, HttpResponseBadRequest, HttpResponseRedirect
+from django.http import HttpResponse, HttpResponseBadRequest, HttpResponseRedirect, Http404
 from django.shortcuts import render, redirect
 from django.core.context_processors import csrf
 from django.core.exceptions import ViewDoesNotExist, PermissionDenied
 from django.contrib.auth.models import User
 from django.contrib.auth.decorators import login_required
 
-from django.utils import simplejson as json
-
 from django.forms.formsets import formset_factory
 from harvardcards.apps.flash.models import Collection, Users_Collections, Deck, Field
 from harvardcards.apps.flash.forms import CollectionForm, FieldForm, DeckForm, CollectionShareForm
 from harvardcards.apps.flash import forms, services, queries, utils
-from harvardcards.apps.flash.services import check_role, is_superuser_or_staff
+from harvardcards.apps.flash.services import check_role
+from harvardcards.apps.flash.queries import is_superuser_or_staff
 from harvardcards.apps.flash.lti_service import LTIService
 
 
@@ -21,50 +20,28 @@ def index(request, collection_id=None):
     """Displays a set of collections to the user depending on whether 
     or not the collections are private or public and whether or not the 
     user has permission."""
-    all_collections = Collection.objects.all()
-    user_collection_role = Users_Collections.get_role_buckets(request.user, collections = all_collections)
-    request.session['role_bucket'] = user_collection_role
 
-    decks_by_collection = queries.getDecksByCollection()
-
-    collection_list = []
-    for collection in all_collections:
-        if not collection.private or services.has_role(request, [Users_Collections.ADMINISTRATOR, 
-                        Users_Collections.INSTRUCTOR, Users_Collections.TEACHING_ASSISTANT, 
-                        Users_Collections.CONTENT_DEVELOPER, Users_Collections.LEARNER], collection.id):
-            collection_decks = []
-            if decks_by_collection.get(collection.id, 0):
-                for deck in decks_by_collection[collection.id]:
-                    collection_decks.append({
-                        'id': deck.id,
-                        'title': deck.title,
-                        'num_cards': deck.cards.count()
-                    })
-                collection_list.append({
-                    'id': collection.id,
-                    'title':collection.title,
-                    'decks': collection_decks
-                })
-            else:
-                collection_list.append({
-                    'id': collection.id,
-                    'title':collection.title,
-                    'decks': []
-                })
+    role_bucket = services.get_or_update_role_bucket(request)
+    collection_list = queries.getCollectionList(role_bucket)
+    active_collection = None
+    display_collections = collection_list
     
     if collection_id:
-        cur_collection = all_collections.get(id=collection_id)
+        try:
+            cur_collection = Collection.objects.get(id=collection_id)
+        except Collection.DoesNotExist:
+            raise Http404
         display_collections = [c for c in collection_list if c['id'] == cur_collection.id]
-        display_collection = display_collections[0]
-    else:
-        display_collections = collection_list
-        display_collection = None
+        if len(display_collections) == 0:
+            raise Http404
+        else:
+            active_collection = display_collections[0]
 
     context = {
-        "collections": collection_list,
+        "nav_collections": collection_list,
         "display_collections": display_collections,
-        "display_collection": display_collection,
-        "user_collection_role": user_collection_role,
+        "active_collection": active_collection,
+        "user_collection_role": role_bucket,
     }
 
     return render(request, 'collections/index.html', context)
@@ -74,7 +51,9 @@ def index(request, collection_id=None):
 def create(request):
     """Creates a collection."""
 
-    collections = Collection.objects.all()
+    role_bucket = services.get_or_update_role_bucket(request)
+    collection_list = queries.getCollectionList(role_bucket)
+
     if request.method == 'POST':
         collection_form = CollectionForm(request.POST)
         if collection_form.is_valid():
@@ -87,15 +66,14 @@ def create(request):
                 
                 #update role_bucket to add admin permission to the user for this newly created collection
                 services.get_or_update_role_bucket(request, collection_id.id, Users_Collections.role_map[Users_Collections.ADMINISTRATOR])
-                
-            response = redirect(collection)
-            return response
+            return redirect(collection)
     else:
         collection_form = CollectionForm()
         
     context = {
+        "nav_collections": collection_list,
+        "active_collection": None,
         "collection_form": collection_form, 
-        "collections": collections
     }
 
     return render(request, 'collections/create.html', context)

--- a/harvardcards/apps/flash/views/deck.py
+++ b/harvardcards/apps/flash/views/deck.py
@@ -22,7 +22,7 @@ def index(request, deck_id=None):
     deck_cards = Decks_Cards.objects.filter(deck=deck).order_by('sort_order').prefetch_related('card__cards_fields_set__field')
     current_collection = Collection.objects.get(id=deck.collection.id)
     collections = [collection for collection in Collection.objects.all().prefetch_related('deck_set') 
-            if not collection.private or services.has_role(request, [Users_Collections.ADMINISTRATOR, 
+            if not collection.private or services.has_role_with_request(request, [Users_Collections.ADMINISTRATOR, 
             Users_Collections.INSTRUCTOR, Users_Collections.TEACHING_ASSISTANT, Users_Collections.CONTENT_DEVELOPER, 
             Users_Collections.LEARNER], collection.id)]
 

--- a/harvardcards/templates/_collection_nav.html
+++ b/harvardcards/templates/_collection_nav.html
@@ -1,23 +1,23 @@
 <div id="navigation">
-    {% if not collection %}
+    {% if not active_collection %}
         {% if user.is_authenticated %}
             <a href="{% url 'collectionCreate' %}" id="addAcourse">Add Collection</a>
         {% endif %}
-	{% endif %}
+    {% endif %}
     <nav class="desktopNav" data-set="mobileNav">
         <ul class="appNav">
             <li>
                 <a href="{% url 'index' %}">Home</a>
             </li>
-            {% for c in collections %}
+            {% for c in nav_collections %}
                 <li>
-                    {% if c == collection %}
+                    {% if c == active_collection %}
                         <a href="{% url 'collectionIndex' c.id %}" class="active">{{ c.title|truncatechars:30 }}</a>
                     {% else %}
                          <a href="{% url 'collectionIndex' c.id %}">{{ c.title|truncatechars:30 }}</a>
                     {% endif %}
 
-                    {% if c == collection %}
+                    {% if c == active_collection %}
                         {% if c.decks|length > 0 %}
                             <ul>
                                 {% for deck in c.decks %}

--- a/harvardcards/templates/collections/index.html
+++ b/harvardcards/templates/collections/index.html
@@ -1,13 +1,13 @@
 {% extends "__layout_left_sidebar.html" %}
 
 {% block sidebar_content %}
-    {% include "_collection_nav.html" with collections=collections collection=display_collection is_edit_mode=is_edit_mode %}
+    {% include "_collection_nav.html" with collections=collections active_collection=active_collection %}
 {% endblock %}
 
 {% block main_content %}
 <div id="content" data-module="collections-index">
-	{% for collection in display_collections %}
-        {% include "_collection_view.html" with collection=collection user_collection_role=user_collection_role is_edit_mode=is_edit_mode %}
+    {% for collection in display_collections %}
+        {% include "_collection_view.html" with collection=collection user_collection_role=user_collection_role %}
     {% endfor %}
 </div>
 {% endblock %}


### PR DESCRIPTION
This PR fixes the collection nav on the index and "Add Collection" views so that the nav is consistent on both views and only shows the user what they have permission to access. Previously, the "Add Collection" view was showing _all_ collections in the navbar, even though the user may not have access to all collections.

@jazahn Can you review this?

---

[FLASH-142](https://jira.huit.harvard.edu/browse/FLASH-142)
