### PR TITLE
feature/fix-deck-rename

### DIFF
--- a/harvardcards/static/js/components/InlineEditor.js
+++ b/harvardcards/static/js/components/InlineEditor.js
@@ -44,10 +44,7 @@ define(['jquery', 'jquery.jeditable', 'jqueryui'], function($) {
 	};
 
 	InlineEditor.prototype.onSuccess = function(data, textStatus, xhr) {
-		var result = this.success.apply(this, arguments);
-		if(result === true || result === false) {
-			this.highlight({color: result ? "yellow" : "red"});
-		}
+		return this.success.apply(this, arguments);
 	};
 
 	InlineEditor.prototype.onError = function(xhr, textStatus, errorThrown) {

--- a/harvardcards/static/js/modules/deck-view.js
+++ b/harvardcards/static/js/modules/deck-view.js
@@ -148,18 +148,27 @@ function initModule() {
 			$("[data-editable]").each(function(index, el) {
 				var $el = $(el);
 				var editable = $el.data('editable') || 'no';
-				var id = $el.data('editable-id') || '';
+				var deck_id = $el.data('editable-id') || '';
 				if(editable !== 'yes') {
 					return;
 				}
 
 				var editor = new InlineEditor($el, {
 					edit: function(editor, value, settings) {
-						var deck = new Deck({ id: id });
-						return deck.rename(value);
+						var deck = new Deck({ id: deck_id });
+						var result = deck.rename(value);
+						editor.value = value;
+						return result;
 					},
 					success: function(data, textStatus, xhr) {
 						var success = data.success;
+						var value = editor.value;
+						if(success === true) {
+							this.highlight({color: 'yellow'});
+							$("#navigation").find("[data-deck-id='"+deck_id+"']").text(value);
+						} else if(success === false) {
+							this.highlight({color: 'false'});
+						}
 						if(!success) {
 							window.alert("Error saving: "+ data.errors[field]);
 						}

--- a/harvardcards/templates/_deck_nav.html
+++ b/harvardcards/templates/_deck_nav.html
@@ -1,43 +1,23 @@
 <div id="navigation"><!-- navigaton (start) -->
-	<nav class="desktopNav" data-set="mobileNav">
-		<ul class="appNav">
-			<li>
-                <a href="{% url 'index' %}">Home</a>
-			</li>
-		    {% for c in collections %}
+<nav class="desktopNav" data-set="mobileNav">
+    <ul class="appNav">
+        <li>
+            <a href="{% url 'index' %}">Home</a>
+        </li>
+        {% for c in collections %}
+        <li>
+            <a href="{% url 'collectionIndex' c.id %}" class="{% if c == collection %}active{% endif%}" data-collection-id="{{c.id}}">{{ c.title|truncatechars:30 }}</a>
+            {% if c == collection and c.deck_set.count > 0 %}
+            <ul>
+                {% for d in c.deck_set.all %}
                 <li>
-                    {% if c == collection %}
-                        <a href="{% url 'collectionIndex' c.id %}" class="active">{{ c.title|truncatechars:30 }}</a>
-                    {% else %}
-                         <a href="{% url 'collectionIndex' c.id %}">{{ c.title|truncatechars:30 }}</a>
-                    {% endif %}
-
-                    {% if c == collection %}
-                        {% if c.deck_set.count > 0 %}
-                        <ul>
-                            {% for d in c.deck_set.all %}
-                            <li>
-                                {% if is_quiz_mode %}
-                                    {% if d == deck %}
-                                        <li><a href="{% url 'deckIndex' d.id %}?mode=quiz" class="active">{{ d.title|truncatechars:30}}</a></li>
-                                    {% else %}
-                                        <li><a href="{% url 'deckIndex' d.id %}?mode=quiz">{{ d.title|truncatechars:30}}</a></li>
-                                    {% endif %}
-                                {% else %}
-                                    {% if d == deck %}
-                                        <li><a href="{% url 'deckIndex' d.id %}" class="active">{{ d.title|truncatechars:30}}</a></li>
-                                    {% else %}
-                                        <li><a href="{% url 'deckIndex' d.id %}">{{ d.title|truncatechars:30}}</a></li>
-                                    {% endif %}
-                                {% endif %}
-
-                            </li>
-                            {% endfor %}
-                        </ul>
-                        {% endif %}
-                    {% endif %}
+                    <a href="{% url 'deckIndex' d.id %}{% if is_quiz_mode %}?mode=quiz{% endif %}" class="{% if d == deck %}active{% endif %}" data-deck-id="{{d.id}}">{{ d.title|truncatechars:30}}</a>
                 </li>
-		    {% endfor %}
-		</ul>
-	</nav>
+                {% endfor %}
+            </ul>
+            {% endif %}
+        </li>
+        {% endfor %}
+    </ul>
+</nav>
 </div><!-- navigaton (end) -->


### PR DESCRIPTION
This PR fixes an issue with the deck rename functionality. The issue is that when you edit the deck name as an instructor, the navigation still shows the old deck name until/unless the page is refreshed. As a result of these changes, the navigation will be updated automatically when the deck is renamed.

@jazahn Can you review this?

---

[FLASH-147](https://jira.huit.harvard.edu/browse/FLASH-147)
