### PR TITLE
feature/edit-deck-name-styling

### DIFF
--- a/harvardcards/static/css/styles.css
+++ b/harvardcards/static/css/styles.css
@@ -842,6 +842,7 @@ a#mobileMenu{
 #cardTemplateContainer .field-label:after { content: ":"; }
 #cardTemplateContainer .field-value { color: darkgray; }
 
+/********** misc utils *************/
 .errorlist {
 	color: red;
 }
@@ -857,6 +858,15 @@ a#mobileMenu{
 	left: 50%;
 	margin-left: -16px;
 	margin-top: -16px;
+}
+
+.jq-editable-courseHeader input {
+	font-size: 1em;
+	font-family: 'League Gothic', Arial, sans-serif;
+	color: #a51c30 !important;
+	background: transparent;
+	padding: 2px;
+	margin: 2px;
 }
 
 @media screen and (min-width: 320px){

--- a/harvardcards/static/js/components/InlineEditor.js
+++ b/harvardcards/static/js/components/InlineEditor.js
@@ -15,6 +15,7 @@ define(['jquery', 'jquery.jeditable', 'jqueryui'], function($) {
 	InlineEditor.prototype.init = function() {
 		var that = this;
 		var editorConfig = {
+			cssclass: 'jq-editable-courseHeader',
 			select: true,
 			submit: "Save",
 			cancel: "Cancel"


### PR DESCRIPTION
This PR fixes the styling of editable deck name to have the same size and color of what is displayed.

@jazahn Can you review this?

---

[FLASH-159](https://jira.huit.harvard.edu/browse/FLASH-159)
