### PR TITLE
feature/fix-share-icon-link

### DIFF
--- a/harvardcards/templates/_collection_view.html
+++ b/harvardcards/templates/_collection_view.html
@@ -10,7 +10,7 @@
             <ul class="adminMenu adminMenuRight">
                 <li><a class="adminMenuBtn hidden-mobile" href="{% url 'collectionEdit' collection.id %}?collection_id={{collection.id}}"><i class="fa fa-pencil"></i> Edit</a></li>
                 <li><a class="adminMenuBtn hidden-mobile" href="{% url 'collectionDelete' collection.id %}?collection_id={{collection.id}}" data-confirm="Are you sure you want to delete: {{collection.title|escape}}?"><i class="fa fa-times-circle"></i> Delete</a></li>
-                <li><a class="adminMenuBtn hidden-mobile" href="{% url 'collectionShare' collection.id %}?collection_id={{collection.id}}"><i class="fa fa-pencil"></i>Share</a></li>
+                <li><a class="adminMenuBtn hidden-mobile" href="{% url 'collectionShare' collection.id %}?collection_id={{collection.id}}"><i class="fa fa-share"></i> Share</a></li>
             </ul>
         {% endif %}
     </div>

--- a/harvardcards/templates/collections/share.html
+++ b/harvardcards/templates/collections/share.html
@@ -20,7 +20,6 @@
             <p>                                                                                                                                                                                
                 <label for="id_link">Share this link:</label>
                 <input class="sharelink" style="padding: 5px" value="{% if request.is_secure %}https{% else %}http{% endif %}://{{request.get_host}}{% url 'collectionShareValidate' secret_share_key=secret_share_key %}" readonly="readonly" size="100" onclick="this.select()" />
-                <a target="_blank" href="{% url 'collectionShareValidate' secret_share_key=secret_share_key %}"><i class="fa fa-share"></i> Share link</a>
             </p> 
             <a href="{% url 'collectionShare' collection.id %}?collection_id={{collection.id}}" class="adminMenuBtn">Back to Share Course</a>
             <a href="{% url 'collectionIndex' collection.id %}" class="adminMenuBtn cancelBtn">Cancel</a>


### PR DESCRIPTION
This PR fixes the share icon so it's not the same as the edit button. It also removes the redundant link on the share view page.

Note: this is not connected to a story in jira but fixes an issue that Bao noticed yesterday.

@jazahn Can you review this?
