### PR TITLE
bugfix/simplejson-deprecation

### DIFF
--- a/harvardcards/apps/flash/api/api.py
+++ b/harvardcards/apps/flash/api/api.py
@@ -1,6 +1,6 @@
 from django.views.decorators.http import require_http_methods
 from django.http import HttpResponse
-from django.utils import simplejson as json
+import json
 
 def root(request):
     result = {"name": "Harvard Cards", "version": "1.0"}

--- a/harvardcards/apps/flash/api/card.py
+++ b/harvardcards/apps/flash/api/card.py
@@ -1,6 +1,5 @@
 from django.views.decorators.http import require_http_methods
 from django.http import HttpResponse
-from django.utils import simplejson as json
 
 from harvardcards.apps.flash.models import Collection, Deck, Card, Cards_Fields, Field, Users_Collections
 from harvardcards.apps.flash.forms import CardEditForm
@@ -8,6 +7,7 @@ from harvardcards.apps.flash import services, queries, utils
 from harvardcards.apps.flash.services import check_role
 from django.db import models
 
+import json
 import urllib2
 from django.utils.datastructures import MultiValueDict
 from django.core.files import File

--- a/harvardcards/apps/flash/api/collection.py
+++ b/harvardcards/apps/flash/api/collection.py
@@ -4,13 +4,13 @@ from django.shortcuts import render, redirect
 from django.core.context_processors import csrf
 from django.core.exceptions import ViewDoesNotExist
 
-from django.utils import simplejson as json
-
 from django.forms.formsets import formset_factory
 from harvardcards.apps.flash.models import Collection, Users_Collections, Deck, Field
 from harvardcards.apps.flash.forms import CollectionForm, FieldForm, DeckForm
 from harvardcards.apps.flash import queries
 from harvardcards.apps.flash.services import check_role
+
+import json
 
 @require_http_methods(["POST"])
 @check_role([Users_Collections.ADMINISTRATOR, Users_Collections.INSTRUCTOR], 'collection')

--- a/harvardcards/apps/flash/api/deck.py
+++ b/harvardcards/apps/flash/api/deck.py
@@ -1,12 +1,13 @@
 from django.views.decorators.http import require_http_methods
 from django.http import HttpResponse
-from django.utils import simplejson as json
 from django.shortcuts import redirect
 
 from harvardcards.apps.flash.models import Collection, Deck, Card, Cards_Fields, Field, Users_Collections
 from harvardcards.apps.flash import forms, queries, utils
 from harvardcards.apps.flash.services import check_role
 from django.db import models
+
+import json
 
 @require_http_methods(["POST"])
 @check_role([Users_Collections.ADMINISTRATOR, Users_Collections.INSTRUCTOR, Users_Collections.TEACHING_ASSISTANT, Users_Collections.CONTENT_DEVELOPER], 'deck')

--- a/harvardcards/apps/flash/tests.py
+++ b/harvardcards/apps/flash/tests.py
@@ -3,7 +3,6 @@ from django.shortcuts import render, redirect
 from django.core.context_processors import csrf
 from django.core.exceptions import ViewDoesNotExist
 
-from django.utils import simplejson as json
 from django.test import TestCase
 from django.core.urlresolvers import reverse
 from django.forms.formsets import formset_factory
@@ -23,6 +22,7 @@ from harvardcards.settings.common import MEDIA_ROOT
 import os
 import unittest
 import mock
+import json
 
 class CollectionTest(TestCase):
     admin_user = None

--- a/harvardcards/apps/flash/views/deck.py
+++ b/harvardcards/apps/flash/views/deck.py
@@ -4,16 +4,16 @@ from django.shortcuts import render, redirect
 from django.core.context_processors import csrf
 from django.core.exceptions import ViewDoesNotExist
 
-from django.utils import simplejson as json
-
 from django.forms.formsets import formset_factory
 from django.forms import widgets
 from harvardcards.apps.flash.models import Collection, Deck, Card, Decks_Cards, Users_Collections
 from harvardcards.apps.flash.forms import CollectionForm, FieldForm, DeckForm, DeckImportForm
 from harvardcards.apps.flash import services, queries, utils
 from harvardcards.apps.flash.services import check_role
+
 from PIL import Image
 import urllib
+import json
 
 def index(request, deck_id=None):
     """Displays the deck of cards for review/quiz."""


### PR DESCRIPTION
This PR fixes the json deprecation warning that is cluttering the logs: `DeprecationWarning: django.utils.simplejson is deprecated; use json instead.`.

@jazahn Can you review?
