### PR TITLE
Feature/tap next card

### DIFF
--- a/harvardcards/static/js/components/slider/TouchSliderPlugin.js
+++ b/harvardcards/static/js/components/slider/TouchSliderPlugin.js
@@ -107,7 +107,7 @@ define(['jquery'], function($) {
 	};
 	
 	// Handles a tap.
-	TouchSliderPlugin.prototoype.tap = function() {
+	TouchSliderPlugin.prototype.tap = function() {
 		this.slider.goToNext();
 	};
 


### PR DESCRIPTION
This PR implements the ability to "tap" on the card to advance to the next card in the deck. To return to the previous card, swipe to the left. The tap functionality is intended to be a shortcut for swiping to the right since it is more common that the user is advancing through the deck.

@jazahn Can you review?
