### PR TITLE
bugfix/revealcard

### DIFF
--- a/harvardcards/static/js/modules/deck-view.js
+++ b/harvardcards/static/js/modules/deck-view.js
@@ -198,7 +198,6 @@ function initModule() {
 		},
 		onKeyDownRevealCard: function(keyCode, callback) {
 			// reveal content when down arrow is pressed
-			console.log("keyCode", keyCode);
 			if(keyCode == 40) {
 				callback(true);
 			} else if(keyCode == 38) {


### PR DESCRIPTION
This PR fixes the keyboard shortcut to reveal the card in "quiz" mode. Pressing the down/up arrows should reveal/hide the back of the card. This was broken due to a change implementing the swipe effect.

@jazahn Can you review?
