### PR TITLE
feature/toggle-canvas-filter

### DIFF
--- a/harvardcards/apps/flash/forms.py
+++ b/harvardcards/apps/flash/forms.py
@@ -22,11 +22,6 @@ class CollectionForm(forms.ModelForm):
         if card_template_query_set is not None:
             self.fields['card_template'].queryset = card_template_query_set
 
-
-    def __init__(self, *args, **kwargs):
-        """Initializes the form."""
-        return super(CollectionForm, self).__init__(*args, **kwargs)
-
     def clean_deck_order(self):
         """
         Cleans and validates the JSON POSTed in the deck_order field.

--- a/harvardcards/apps/flash/queries.py
+++ b/harvardcards/apps/flash/queries.py
@@ -4,6 +4,7 @@ observable state of the system (are free of side effects).
 """
 
 from harvardcards.apps.flash.models import Collection, Users_Collections, Deck, Decks_Cards
+from harvardcards.settings.common import FEATURE_TOGGLE
 
 import logging
 log = logging.getLogger(__name__)
@@ -40,8 +41,9 @@ def getCollectionList(role_bucket, collection_ids=False):
     log.debug("role_bucket = %s collection_ids = %s" % (role_bucket, collection_ids))
 
     collections = Collection.objects.all()
-    if collection_ids:
-        collections = collections.filter(id__in=collection_ids)
+    if FEATURE_TOGGLE['CANVAS_COURSE_FILTER']:
+        if collection_ids:
+            collections = collections.filter(id__in=collection_ids)
     decks_by_collection = getDecksByCollection(collection_ids=collection_ids)
     collection_roles = getCollectionRoleList()
 

--- a/harvardcards/settings/common.py
+++ b/harvardcards/settings/common.py
@@ -182,6 +182,23 @@ LOGGING = {
     }
 }
 
+# This defines feature toggles for deploying new features.
+FEATURE_TOGGLE = {
+    # DESCRIPTION:
+    #   When enabled, will filter out any collections that 
+    #   are not directly associated with the canvas course.
+    #   
+    #   Feature toggle created to "dark launch" this functionality
+    #   because we want to merge the code, but don't want to change
+    #   the existing behavior until the end of the semester. 
+    # SEE ALSO: 
+    #   See github pull request #106 and Jira FLASH-200.
+    # TODO: 
+    #   Remove feature toggle here and in queries.py when activated.
+    "CANVAS_COURSE_FILTER": False 
+}
+
+
 if DEBUG:
     LOGGING['loggers']['harvardcards']['level'] = 'DEBUG'
     #LOGGING['loggers']['harvardcards']['handlers'] += ['console']


### PR DESCRIPTION
Added feature toggle for canvas collection filter in order to integrate this functionality without activating it just yet. We don't want to change the existing behavior, that is, what collections the user sees in Canvas, until the end of the semester. 
