### PR TITLE
feature/deck-reorder-icon

### DIFF
--- a/harvardcards/templates/collections/edit.html
+++ b/harvardcards/templates/collections/edit.html
@@ -39,7 +39,7 @@
                 {% if collection_decks|length > 0 %}
                     <ul id="sortable-decks">
                         {% for deck in collection_decks %}
-                            <li data-deck-id="{{deck.id}}">{{ deck.title|truncatechars:40}}</li>
+                            <li data-deck-id="{{deck.id}}"><i class="fa fa-bars" style="margin-right: 10px"></i> {{ deck.title|truncatechars:40}}</li>
                         {% endfor %}
                     </ul>
                 {% endif %}


### PR DESCRIPTION
This PR adds the [bars icon](http://fortawesome.github.io/Font-Awesome/icon/bars/) to the reorder list so the user knows they can drag and drop the items (thanks for the tip @jazahn).

![screen shot 2014-11-18 at 2 41 30 pm](https://cloud.githubusercontent.com/assets/1165361/5094679/0515850c-6f31-11e4-99ae-0d15f89f2569.png)
