### PR TITLE
bugfix/zipdownload

### DIFF
--- a/harvardcards/apps/flash/utils.py
+++ b/harvardcards/apps/flash/utils.py
@@ -169,7 +169,7 @@ def create_deck_file(deck_id):
         for idx, field in enumerate(card['fields']):
             field_value = field['value']
             field_type = field['type']
-            if field_type == 'T' or field_type == 'A':
+            if field_type == 'I' or field_type == 'A':
                 field_value = os.path.split(field_value)[1] # strips the media folder path
             worksheet.write(row, idx, label=field_value)
 


### PR DESCRIPTION
Fixes the downloaded ZIP for decks with images. The fields with images should have the media folder stripped from the spreadsheet. That is, image fields should look like this: `BartSimpson.gif` not this: `44_56/BartSimpson.gif`.
