### PR TITLE
Bugfix/audio autoplay

### DIFF
--- a/harvardcards/static/js/components/slider/DeckSlider.js
+++ b/harvardcards/static/js/components/slider/DeckSlider.js
@@ -131,7 +131,6 @@ define(['jquery', 'microevent', 'components/slider/Slider'], function($, MicroEv
 			card_ids.push(this.card_ids[index+i]);
 			this.loaded[index+i] = true;
 		}
-		console.log("trigger load", index, card_ids);
 		this.trigger("load", this, card_ids);
 	};
 

--- a/harvardcards/static/js/modules/deck-view.js
+++ b/harvardcards/static/js/modules/deck-view.js
@@ -45,7 +45,6 @@ function initModule() {
 		// find the card elements
 		var $controls = $cardDetail.find(".controls[data-card-id="+data.card_id+"]");
 		var $card = $cardDetail.find(".card[data-card-id="+data.card_id+"]");
-		console.log("slide", data.card_id);
 		var playAudio = MODULE.makeAudioPlayer($card);
 
 		var slideOpts = {
@@ -291,7 +290,7 @@ function initModule() {
 			var $audio = $card.find("audio").first(); 
 			var audio = ($audio.length == 1 ? $audio[0] : false);
 			return function() {
-				console.log("play audio", $card.data('card-id'));
+				//console.log("play audio", $card.data('card-id'));
 				MODULE.pauseAllAudio($('audio'));
 				if(audio) {
 					if(window.chrome) {


### PR DESCRIPTION
This PR fixes an issue where the audio would not automatically play on every fourth card. This was a result of an issue with the lazy loading (buffer size = 4).

@jazahn Can you review this?
