### PR TITLE
feature/merge-canvas-course-filter

### DIFF
--- a/harvardcards/apps/flash/queries.py
+++ b/harvardcards/apps/flash/queries.py
@@ -4,7 +4,6 @@ observable state of the system (are free of side effects).
 """
 
 from harvardcards.apps.flash.models import Collection, Users_Collections, Deck, Decks_Cards
-from harvardcards.settings.common import FEATURE_TOGGLE
 
 import logging
 log = logging.getLogger(__name__)
@@ -41,13 +40,10 @@ def getCollectionList(role_bucket, collection_ids=False):
     log.debug("role_bucket = %s collection_ids = %s" % (role_bucket, collection_ids))
 
     collections = Collection.objects.all()
-    if FEATURE_TOGGLE['CANVAS_COURSE_FILTER']:
-        if collection_ids:
-            collections = collections.filter(id__in=collection_ids)
-    if FEATURE_TOGGLE['CANVAS_COURSE_FILTER']:
-        decks_by_collection = getDecksByCollection(collection_ids=collection_ids)
-    else:
-        decks_by_collection = getDecksByCollection()
+    if collection_ids:
+        collections = collections.filter(id__in=collection_ids)
+
+    decks_by_collection = getDecksByCollection(collection_ids=collection_ids)
 
     collection_roles = getCollectionRoleList()
 

--- a/harvardcards/settings/common.py
+++ b/harvardcards/settings/common.py
@@ -195,26 +195,21 @@ LOGGING = {
     }
 }
 
-# This defines feature toggles for deploying new features.
+# This defines feature toggles for deploying new features without
+# enabling them.
+#
+# Usage:
+#       from django.conf import settings
+#       if settings.FEATURE_TOGGLE['X_ENABLED']:
+#           do_something()
+#       
 FEATURE_TOGGLE = {
-    # DESCRIPTION:
-    #   When enabled, will filter out any collections that 
-    #   are not directly associated with the canvas course.
-    #   
-    #   Feature toggle created to "dark launch" this functionality
-    #   because we want to merge the code, but don't want to change
-    #   the existing behavior until the end of the semester. 
-    # SEE ALSO: 
-    #   See github pull request #106 and Jira FLASH-200.
-    # TODO: 
-    #   Remove feature toggle here and in queries.py when activated.
-    "CANVAS_COURSE_FILTER": False 
+        # "X_ENABLED" => True|False
 }
-
 
 if DEBUG:
     LOGGING['loggers']['harvardcards']['level'] = 'DEBUG'
-    LOGGING['loggers']['harvardcards']['handlers'] += ['console']
+    #LOGGING['loggers']['harvardcards']['handlers'] += ['console']
 
 OPENID_CREATE_USERS = True
 OPENID_UPDATE_DETAILS_FROM_SREG = True

--- a/harvardcards/settings/common.py
+++ b/harvardcards/settings/common.py
@@ -195,9 +195,7 @@ LOGGING = {
     }
 }
 
-# This defines feature toggles for deploying new features without
-# enabling them.
-#
+# This dictionary defines application-level feature toggles. 
 # Usage:
 #       from django.conf import settings
 #       if settings.FEATURE_TOGGLE['X_ENABLED']:
@@ -209,7 +207,7 @@ FEATURE_TOGGLE = {
 
 if DEBUG:
     LOGGING['loggers']['harvardcards']['level'] = 'DEBUG'
-    #LOGGING['loggers']['harvardcards']['handlers'] += ['console']
+    LOGGING['loggers']['harvardcards']['handlers'] += ['console']
 
 OPENID_CREATE_USERS = True
 OPENID_UPDATE_DETAILS_FROM_SREG = True


### PR DESCRIPTION
This PR merges the canvas course filter feature into the codebase by removing the feature toggle that was previously implemented and deployed, but not released (see github pull request #106 and Jira FLASH-200). This feature is now being "released" so there's no need for the feature toggle anymore.

The effect of this change is that now when you launch the tool in a canvas course, you will only see your collections associated with *that* course. If you have collections associated with other courses, you will need to visit those courses.

@jazahn Can you review this?