### PR TITLE
Feature/add collection modal

### DIFF
--- a/harvardcards/apps/flash/views/collection.py
+++ b/harvardcards/apps/flash/views/collection.py
@@ -64,7 +64,7 @@ def custom_create(request):
     Creates a collection with custom template.
     """
     upload_error = ''
-
+    course_name = ''
     role_bucket = services.get_or_update_role_bucket(request)
     canvas_course_collections = LTIService(request).getCourseCollections()
     collection_list = queries.getCollectionList(role_bucket, collection_ids=canvas_course_collections)
@@ -94,7 +94,8 @@ def custom_create(request):
     context = {
         "nav_collections": collection_list,
         "active_collection": None,
-        'upload_error': upload_error
+        'upload_error': upload_error,
+        "course_name": course_name or ''
     }
 
     analytics.track(

--- a/harvardcards/static/css/styles.css
+++ b/harvardcards/static/css/styles.css
@@ -279,10 +279,23 @@ a#addAcourse
 	margin: 0;
 	padding: 0.25em 10%;
 }
-a.unstyled {
-    color: #4c4c4c;
-    text-decoration: none;
+
+ul.addACourseContent > li {
+    display: block;
+    height: 150px;
+    width: 38%;
+    margin-left: 10%;
+    float: left;
+    border-right: 1px solid #aaa;
 }
+ul.addACourseContent > li:last-child {
+    border-right: none;
+}
+ul.addACourseContent h2,
+ul.addACourseContent div {
+    margin: 0 0 10px 0;
+}
+
 
 /*a#addCard{
 	margin: 0;

--- a/harvardcards/static/css/styles.css
+++ b/harvardcards/static/css/styles.css
@@ -271,12 +271,12 @@ a#addAcourse
 	text-align: center;
 	text-decoration: none;
 	display: block;
-	width: 30%;
+	width: 20%;
 	font-size: 1.875em;
 	color: #4c4c4c;
 	border: 2px dashed #838383;
 	text-transform:uppercase;
-	margin: 0 auto 0.25em;
+	margin: 0;
 	padding: 0.25em 10%;
 }
 a.unstyled {
@@ -329,9 +329,14 @@ a.unstyled {
 	margin-bottom: 1em;
 }
 .courseHeaderClickable {
-    padding: .5em 1em;
+    padding: .5em 0;
     cursor: pointer;
     background-color: lightgrey;
+}
+.courseHeaderClickable > .plusminus,
+.courseHeaderClickable > .adminMenuRight {
+    margin-left: .5em;
+    margin-right: .5em;
 }
 .addCourseWrapper{
 	display: none;
@@ -396,7 +401,7 @@ a.unstyled {
         width: 100%;
     }
     .deck dl dt {
-        font-weight: bold;
+        font-weight: normal;
         float:left;
         width:40%;
     }

--- a/harvardcards/static/js/modules/collections-index.js
+++ b/harvardcards/static/js/modules/collections-index.js
@@ -1,59 +1,12 @@
-define(['jquery', 'utils/utils', 'jqueryui'], function($, utils) {
-
-    var CollectionListView = {
-        init: function() {
-            var self = this;
-
-            this.allCollapsed = true;
-
-            this.getHeaderEls().click(function() {
-                self.toggleCollapse(this);
-            });
-
-            this.getExpandCollapseAllBtn().click(function() {
-                var el = this;
-                self.toggleCollapse(self.getHeaderEls(), self.allCollapsed);
-                self.allCollapsed = !self.allCollapsed;
-                $(el).find('span').html(self.allCollapsed?'Expand All':'Collapse All');
-                self.togglePlusMinusCls(el);
-            });
-
-            this.getHeaderEls().each(function(index, el) {
-                var collection_id = $(el).data('collection-id');
-                var collection_state = localStorage.getItem('show-collection-id'+collection_id);
-
-                if(collection_state == 'true'){
-                    self.toggleCollapse(el, true);
-                } else if(collection_state == undefined){
-                    self.toggleCollapse(el, false);
-                }
-            });
-        },
-        getHeaderEls: function() {
-            return $('.courseHeader');
-        },
-        getExpandCollapseAllBtn: function() {
-            return $('#expandCollapseAllBtn');
-        },
-        toggleCollapse: function(headerEls, state) {
-            var self = this;
-            $(headerEls).each(function(index, el) {
-                var courseBody = $(el).next();
-                var visible = $(courseBody).is(":visible");
-                if(typeof state === 'undefined' || state != visible) {
-                    $(courseBody).slideToggle('slow', function(){
-                        var collection_id = $(el).data('collection-id');
-                        var visible = $(courseBody).is(":visible");
-                        localStorage.setItem('show-collection-id'+collection_id, visible);
-                    });
-                    self.togglePlusMinusCls(el);
-                }
-            });
-        },
-        togglePlusMinusCls: function(el) {
-            $(el).find('.plusminus').toggleClass('fa-plus-circle fa-minus-circle');
-        }
-    };
+define([
+'jquery',
+'jqueryui',
+'views/CollectionListView'
+],
+function(
+$,
+$ui,
+CollectionListView) {
 
     var CollectionCreateModal = {
         init: function() {
@@ -65,7 +18,9 @@ define(['jquery', 'utils/utils', 'jqueryui'], function($, utils) {
             console.log("click", this, arguments);
             $("#addAcourseDialog").dialog({
                 modal: true,
-                width: '95%',
+                width: '60%',
+                position: { my: "top", at: "top+20px", of: window },
+                closeOnEscape: true,
                 buttons: {
                     Cancel: function() {
                         $(this).dialog("close");
@@ -81,7 +36,12 @@ define(['jquery', 'utils/utils', 'jqueryui'], function($, utils) {
 
     return {
 		initModule: function(){
-		    CollectionListView.init();
+		    var collection_list_view = new CollectionListView({
+		        headerSelector: ".courseHeader",
+		        btnSelector: "#expandCollapseAllBtn"
+		    });
+
+			collection_list_view.init();
 		    CollectionCreateModal.init();
 		}
 	};

--- a/harvardcards/static/js/modules/collections-index.js
+++ b/harvardcards/static/js/modules/collections-index.js
@@ -1,38 +1,4 @@
-define([
-'jquery',
-'jqueryui',
-'views/CollectionListView'
-],
-function(
-$,
-$ui,
-CollectionListView) {
-
-    var CollectionCreateModal = {
-        init: function() {
-            console.log("init modal");
-            this.modalHandler = $.proxy(this.modalHandler, this);
-            $("#addAcourse").click(this.modalHandler);
-        },
-        modalHandler: function(evt) {
-            console.log("click", this, arguments);
-            $("#addAcourseDialog").dialog({
-                modal: true,
-                width: '60%',
-                position: { my: "top", at: "top+20px", of: window },
-                closeOnEscape: true,
-                buttons: {
-                    Cancel: function() {
-                        $(this).dialog("close");
-                    }
-                },
-                open: function(event, ui) {
-                    console.log("event: open", event, ui);
-                }
-            });
-            return false;
-        }
-    };
+define(['jquery','views/CollectionListView','views/CollectionCreateModal'], function($,CollectionListView, CollectionCreateModal) {
 
     return {
 		initModule: function(){
@@ -41,8 +7,13 @@ CollectionListView) {
 		        btnSelector: "#expandCollapseAllBtn"
 		    });
 
+		    var collection_create_modal = new CollectionCreateModal({
+		        btnSelector: "#addAcourse",
+		        dialogSelector: "#addAcourseDialog"
+		    });
+
 			collection_list_view.init();
-		    CollectionCreateModal.init();
+			collection_create_modal.init();
 		}
 	};
 });

--- a/harvardcards/static/js/modules/collections-index.js
+++ b/harvardcards/static/js/modules/collections-index.js
@@ -1,56 +1,88 @@
-define(['jquery', 'utils/utils'], function($, utils) {
-    var courseAccordion = function(courseHeader){
-        var courseBody = $(courseHeader).next();
-        $(courseBody).slideToggle('slow', function(){
-            var collection_id = $(courseHeader).data('collection-id');
-            if($(courseBody).is(":visible")){
-                localStorage.setItem('show-collection-id'+collection_id, true);
-            } else {
-                localStorage.setItem('show-collection-id'+collection_id, false);
-            }
-        });
-        $(courseHeader).find('.plusminus').toggleClass("fa-plus-circle fa-minus-circle");
-        return true;
-    }
+define(['jquery', 'utils/utils', 'jqueryui'], function($, utils) {
 
-    var currently = 'all open';
-    var expandCollapseAll = function(){
-        $('.courseHeader').each(function(index){
-            var el = this;
-            var body = $(el).next();
-            var collection_id = $(el).data('collection-id');
-            if(currently == 'all open'){
-                $(body).slideDown('slow');
-                localStorage.setItem('show-collection-id'+collection_id, true);
-            } else {
-                $(body).slideUp('slow');
-                localStorage.setItem('show-collection-id'+collection_id, false);
-            }
-        });
-        if(currently == 'all open'){
-            currently = 'all closed';
-        } else {
-            currently = 'all open';
+    var CollectionListView = {
+        init: function() {
+            var self = this;
+
+            this.allCollapsed = true;
+
+            this.getHeaderEls().click(function() {
+                self.toggleCollapse(this);
+            });
+
+            this.getExpandCollapseAllBtn().click(function() {
+                var el = this;
+                self.toggleCollapse(self.getHeaderEls(), self.allCollapsed);
+                self.allCollapsed = !self.allCollapsed;
+                $(el).find('span').html(self.allCollapsed?'Expand All':'Collapse All');
+                self.togglePlusMinusCls(el);
+            });
+
+            this.getHeaderEls().each(function(index, el) {
+                var collection_id = $(el).data('collection-id');
+                var collection_state = localStorage.getItem('show-collection-id'+collection_id);
+
+                if(collection_state == 'true'){
+                    self.toggleCollapse(el, true);
+                } else if(collection_state == undefined){
+                    self.toggleCollapse(el, false);
+                }
+            });
+        },
+        getHeaderEls: function() {
+            return $('.courseHeader');
+        },
+        getExpandCollapseAllBtn: function() {
+            return $('#expandCollapseAllBtn');
+        },
+        toggleCollapse: function(headerEls, state) {
+            var self = this;
+            $(headerEls).each(function(index, el) {
+                var courseBody = $(el).next();
+                var visible = $(courseBody).is(":visible");
+                if(typeof state === 'undefined' || state != visible) {
+                    $(courseBody).slideToggle('slow', function(){
+                        var collection_id = $(el).data('collection-id');
+                        var visible = $(courseBody).is(":visible");
+                        localStorage.setItem('show-collection-id'+collection_id, visible);
+                    });
+                    self.togglePlusMinusCls(el);
+                }
+            });
+        },
+        togglePlusMinusCls: function(el) {
+            $(el).find('.plusminus').toggleClass('fa-plus-circle fa-minus-circle');
         }
+    };
 
-    }
-
+    var CollectionCreateModal = {
+        init: function() {
+            console.log("init modal");
+            this.modalHandler = $.proxy(this.modalHandler, this);
+            $("#addAcourse").click(this.modalHandler);
+        },
+        modalHandler: function(evt) {
+            console.log("click", this, arguments);
+            $("#addAcourseDialog").dialog({
+                modal: true,
+                width: '95%',
+                buttons: {
+                    Cancel: function() {
+                        $(this).dialog("close");
+                    }
+                },
+                open: function(event, ui) {
+                    console.log("event: open", event, ui);
+                }
+            });
+            return false;
+        }
+    };
 
     return {
 		initModule: function(){
-            $('.courseHeader').click(function(){ return courseAccordion(this); });
-            $('#expandCollapseAllBtn').click(expandCollapseAll);
-
-            $('.courseHeader').each(function(index){
-                var el = this;
-                var collection_id = $(el).data('collection-id');
-                if(localStorage.getItem('show-collection-id'+collection_id) == 'true'){
-                    courseAccordion(el);
-                } else if(localStorage.getItem('show-collection-id'+collection_id) == undefined){
-                    courseAccordion(el);
-                }
-            });
-
+		    CollectionListView.init();
+		    CollectionCreateModal.init();
 		}
 	};
 });

--- a/harvardcards/static/js/views/CollectionCreateModal.js
+++ b/harvardcards/static/js/views/CollectionCreateModal.js
@@ -1,0 +1,35 @@
+define(['jquery', 'jqueryui'], function($, $ui) {
+
+    var CollectionCreateModal = function(options) {
+        this.options = options;
+        this.btnSelector = this.options.btnSelector;
+        this.dialogSelector = this.options.dialogSelector;
+    };
+
+    $.extend(CollectionCreateModal.prototype, {
+        init: function() {
+            this.modalHandler = $.proxy(this.modalHandler, this);
+
+            $(this.btnSelector).click(this.modalHandler);
+        },
+        modalHandler: function(evt) {
+            $(this.dialogSelector).dialog({
+                modal: true,
+                width: '60%',
+                position: { my: "top", at: "top+20px", of: window },
+                closeOnEscape: true,
+                buttons: {
+                    Cancel: function() {
+                        $(this).dialog("close");
+                    }
+                },
+                open: function(event, ui) {
+                    //console.log("event: open", event, ui);
+                }
+            });
+            return false;
+        }
+    });
+
+    return CollectionCreateModal;
+});

--- a/harvardcards/static/js/views/CollectionListView.js
+++ b/harvardcards/static/js/views/CollectionListView.js
@@ -4,7 +4,6 @@ define(['jquery'], function($) {
         this.options = options;
         this.headerSelector = this.options.headerSelector;
         this.btnSelector = this.options.btnSelector;
-        console.log(this);
     };
 
     $.extend(CollectionListView.prototype, {

--- a/harvardcards/static/js/views/CollectionListView.js
+++ b/harvardcards/static/js/views/CollectionListView.js
@@ -1,0 +1,66 @@
+define(['jquery'], function($) {
+
+    var CollectionListView = function(options) {
+        this.options = options;
+        this.headerSelector = this.options.headerSelector;
+        this.btnSelector = this.options.btnSelector;
+        console.log(this);
+    };
+
+    $.extend(CollectionListView.prototype, {
+        init: function() {
+            var self = this;
+
+            this.allCollapsed = true;
+
+            this.getHeaderEls().click(function() {
+                self.toggleCollapse(this);
+            });
+
+            this.getExpandCollapseAllBtn().click(function() {
+                var el = this;
+                self.toggleCollapse(self.getHeaderEls(), self.allCollapsed);
+                self.allCollapsed = !self.allCollapsed;
+                $(el).find('span').html(self.allCollapsed?'Expand All':'Collapse All');
+                self.togglePlusMinusCls(el);
+            });
+
+            this.getHeaderEls().each(function(index, el) {
+                var collection_id = $(el).data('collection-id');
+                var collection_state = localStorage.getItem('show-collection-id'+collection_id);
+
+                if(collection_state == 'true'){
+                    self.toggleCollapse(el, true);
+                } else if(collection_state == undefined){
+                    self.toggleCollapse(el, false);
+                }
+            });
+        },
+        getHeaderEls: function() {
+            return $(this.headerSelector);
+        },
+        getExpandCollapseAllBtn: function() {
+            return $(this.btnSelector);
+        },
+        toggleCollapse: function(headerEls, state) {
+            var self = this;
+            $(headerEls).each(function(index, el) {
+                var courseBody = $(el).next();
+                var visible = $(courseBody).is(":visible");
+                if(typeof state === 'undefined' || state != visible) {
+                    $(courseBody).slideToggle('slow', function(){
+                        var collection_id = $(el).data('collection-id');
+                        var visible = $(courseBody).is(":visible");
+                        localStorage.setItem('show-collection-id'+collection_id, visible);
+                    });
+                    self.togglePlusMinusCls(el);
+                }
+            });
+        },
+        togglePlusMinusCls: function(el) {
+            $(el).find('.plusminus').toggleClass('fa-plus-circle fa-minus-circle');
+        }
+    });
+
+    return CollectionListView;
+});

--- a/harvardcards/templates/_collection_view.html
+++ b/harvardcards/templates/_collection_view.html
@@ -20,7 +20,7 @@
     {% for deck in collection.decks %}
         <li class="deck">
             <dl>
-                <dt><a class="unstyled" href="{% url 'deckIndex' deck.id %}">{{ deck.title }}</a></dt>
+                <dt><a href="{% url 'deckIndex' deck.id %}">{{ deck.title }}</a></dt>
                 <dd>{{ deck.num_cards }} {% if deck.num_cards == 1 %}Card {% else %}Cards{% endif %}</dd>
                 <dd><a class="adminMenuBtn" href="{% url 'deckIndex' deck.id %}">Review</a></dd>
                 <dd><a class="adminMenuBtn" href="{% url 'deckIndex' deck.id %}?mode=quiz">Quiz</a></dd>

--- a/harvardcards/templates/collections/create.html
+++ b/harvardcards/templates/collections/create.html
@@ -22,7 +22,7 @@
                 {{ collection_form.card_template }}
                 <span class="form-help">Choose a template to use when creating flashcards.</span>
             </div>
-            <a href="{% url 'collectionCustom' %}" class="adminMenuBtn cancelBtn">Custom Collection</a>
+
             <div class="clear"><!-- empty --></div>
             
             <div id="cardTemplateContainer" data-fetch-url="{% url 'cardTemplatePreview' %}" data-default-text="Select a template">

--- a/harvardcards/templates/collections/custom.html
+++ b/harvardcards/templates/collections/custom.html
@@ -7,13 +7,11 @@
 {% block main_content %}
 <div id="content" data-module="collections-custom">
   <div class="courseWrapper">
-
-
         <form id="customForm" action="{% url 'customDeckUpload' %}" method="post" enctype="multipart/form-data">
             {% csrf_token %}
             <div class="courseHeader">
                 <label for="id_title" style="visibility:hidden;text-indent:-300px;position:absolute;">Title:</label>
-                <input id="id_title" name="course" type="text" autofocus placeholder="Enter collection name here">
+                <input id="id_title" name="course" type="text" autofocus placeholder="Enter collection name here" value="{{course_name}}">
             </div>
             <div style="margin: 1em 0;">Steps to create a customized collection:</div>
             <ol class="help" style="margin-bottom: 1em">

--- a/harvardcards/templates/collections/index.html
+++ b/harvardcards/templates/collections/index.html
@@ -8,24 +8,44 @@
 <div id="content" data-module="collections-index">
     {% if not active_collection %}
         {% if user.is_authenticated %}
-            <div style="width:100%"><a href="{% url 'collectionCreate' %}" id="addAcourse">Add Collection</a></div>
+            <div class="hidden-mobile">
+                <a href="{% url 'collectionCreate' %}" id="addAcourse">Add Collection</a>
+            </div>
         {% endif %}
     {% endif %}
-    <ul class="adminMenu adminMenuRight">
+
+    {% if display_collections|length > 0 %}
+        <ul class="adminMenu adminMenuRight">
+            <li>
+                <button type="button" class="adminMenuBtn" id="expandCollapseAllBtn"><i class="plusminus fa fa-plus-circle"></i> <span>Expand All</span></button>
+            </li>
+            <li>
+                <a class="adminMenuBtn hidden-mobile" href="{% url 'help' %}"><i class="fa fa-question-circle"></i> Help</a>
+            </li>
+        </ul>
+        <div class="clear"></div>
+        <ul class="accordion" style="margin-top: .5em">
+        {% for collection in display_collections %}
+            <li>
+            {% include "_collection_view.html" with collection=collection user_collection_role=user_collection_role %}
+            </li>
+        {% endfor %}
+        </ul>
+    {% endif %}
+</div>
+
+<div id="addAcourseDialog" style="display:none" title="Add Collection">
+    <ul class="addACourseContent">
         <li>
-            <button type="button" class="adminMenuBtn" id="expandCollapseAllBtn">Expand / Collapse All</button>
+            <h2>Add a New Collection</h2>
         </li>
         <li>
-            <a class="adminMenuBtn hidden-mobile" href="{% url 'help' %}"><i class="fa fa-question-circle"></i> Help</a>
+            <h2>Custom Import</h2>
+        </li>
+        <li>
+            <h2>Duplicate From Existing Collection</h2>
         </li>
     </ul>
 
-    <ul class="accordion">
-    {% for collection in display_collections %}
-        <li>
-        {% include "_collection_view.html" with collection=collection user_collection_role=user_collection_role %}
-        </li>
-    {% endfor %}
-    </ul>
 </div>
 {% endblock %}

--- a/harvardcards/templates/collections/index.html
+++ b/harvardcards/templates/collections/index.html
@@ -38,14 +38,26 @@
     <ul class="addACourseContent">
         <li>
             <h2>Add a New Collection</h2>
+            <div><a href="{% url 'collectionCreate' %}" class="adminMenuBtn">Add a New Collection</a></div>
         </li>
         <li>
             <h2>Custom Import</h2>
+            <div><a href="{% url 'collectionCustom' %}" class="adminMenuBtn">Import Collection</a></div>
         </li>
+        <!--
         <li>
             <h2>Duplicate From Existing Collection</h2>
+            <div>My collections:</div>
+            <div>
+                <select>
+                    <option>Test</option>
+                </select>
+            </div>
+            <div>
+                <a href="#" class="adminMenuBtn">Add to Course</a>
+            </div>
         </li>
+        -->
     </ul>
-
 </div>
 {% endblock %}

--- a/harvardcards/templates/collections/index.html
+++ b/harvardcards/templates/collections/index.html
@@ -44,7 +44,7 @@
             <h2>Custom Import</h2>
             <div><a href="{% url 'collectionCustom' %}" class="adminMenuBtn">Import Collection</a></div>
         </li>
-        <!-- TODO 
+        <!-- TODO
         <li>
             <h2>Duplicate From Existing Collection</h2>
             <div>My collections:</div>

--- a/harvardcards/templates/collections/index.html
+++ b/harvardcards/templates/collections/index.html
@@ -44,7 +44,7 @@
             <h2>Custom Import</h2>
             <div><a href="{% url 'collectionCustom' %}" class="adminMenuBtn">Import Collection</a></div>
         </li>
-        <!--
+        <!-- TODO 
         <li>
             <h2>Duplicate From Existing Collection</h2>
             <div>My collections:</div>


### PR DESCRIPTION
This PR modifies the course index screen so that when you click the *Add Collection* button, a modal pops up that displays the different ways you can create a collection. For now, there are two ways: 

1. Add new collection - creates an empty collection with one of the existing templates.
2. Custom import - creates a collection using the template defined in a spreadsheet and imports one deck of cards.

This tees up [FLASH-229](https://jira.huit.harvard.edu/browse/FLASH-229) which will add a third option:

3. Duplicate Existing Collection - copies an existing collection that belongs to the user.

As part of this story, I moved the list view JS and modal JS into their own definition files.

@jazahn review?

---
[FLASH-228](https://jira.huit.harvard.edu/browse/FLASH-228)