### PR TITLE
Feature/admin user collections

### DIFF
--- a/harvardcards/apps/flash/admin.py
+++ b/harvardcards/apps/flash/admin.py
@@ -4,10 +4,16 @@ from django.contrib.auth.models import User
 from django.contrib.auth.admin import UserAdmin
 
 class UserAdminCustom(UserAdmin):
-    list_display = UserAdmin.list_display + ('num_collections',)
+    list_display = ( UserAdmin.list_display[0], 'num_collections', UserAdmin.list_display[-1])
     def num_collections(self, obj):
         return Users_Collections.objects.filter(user=obj).count()
 
+    def queryset(self, request):
+        return User.objects.extra(
+            select={'num_collections': "select count(*) from flash_users_collections where flash_users_collections.user_id = auth_user.id"},
+            )
+    num_collections.admin_order_field = 'num_collections'
+    num_collections.short_description = 'Number of Collections'
 
 class CardsInLine(admin.StackedInline):
     verbose_name = "Card's fields"

--- a/harvardcards/apps/flash/admin.py
+++ b/harvardcards/apps/flash/admin.py
@@ -1,6 +1,13 @@
 from django.contrib import admin
 from harvardcards.apps.flash.models import *
 from django.contrib.auth.models import User
+from django.contrib.auth.admin import UserAdmin
+
+class UserAdminCustom(UserAdmin):
+    list_display = UserAdmin.list_display + ('num_collections',)
+    def num_collections(self, obj):
+        return Users_Collections.objects.filter(user=obj).count()
+
 
 class CardsInLine(admin.StackedInline):
     verbose_name = "Card's fields"
@@ -51,6 +58,8 @@ class ClonedAdmin(admin.ModelAdmin):
 class MediaStoreAdmin(admin.ModelAdmin):
     list_display = ('id', 'file_name', 'file_md5hash', 'file_type', 'file_size', 'store_created', 'store_updated', 'reference_count')
 
+admin.site.unregister(User)
+admin.site.register(User, UserAdminCustom)
 admin.site.register(Collection, CollectionAdmin)
 admin.site.register(Field)
 admin.site.register(Card, CardAdmin)

--- a/harvardcards/apps/flash/views/stats_graph.py
+++ b/harvardcards/apps/flash/views/stats_graph.py
@@ -1,0 +1,38 @@
+from django.http import HttpResponse
+from django.template import RequestContext, loader
+from django.views.decorators.http import require_http_methods
+from django.shortcuts import render, redirect
+from django.core.context_processors import csrf
+from django.forms import widgets
+
+from harvardcards.apps.flash.models import Collection, Deck, Card, Decks_Cards, Users_Collections, User
+from harvardcards.apps.flash.forms import DeckImportForm
+from harvardcards.apps.flash.decorators import check_role
+from harvardcards.apps.flash.lti_service import LTIService
+from harvardcards.apps.flash import services, queries, analytics
+from django.contrib.auth.decorators import user_passes_test
+
+import PIL
+import PIL.Image
+import StringIO
+from matplotlib import pylab
+from pylab import *
+import numpy as np
+
+@user_passes_test(lambda u: u.is_superuser or u.is_staff)
+def graph_collections(request):
+    objects =  Users_Collections.objects.all().values()
+    objects = map(lambda o: o['user_id'], objects)
+    users = map(lambda u: u['id'], User.objects.all().values('id'))
+    x = map(lambda u: objects.count(u), users)
+    hist(x)
+    xlabel('Number of Collections')
+    ylabel('Number of Users')
+    title('Histogram of Number of Collections Associated with Users')
+    buffer = StringIO.StringIO()
+    canvas = pylab.get_current_fig_manager().canvas
+    canvas.draw()
+    graphIMG = PIL.Image.fromstring('RGB', canvas.get_width_height(), canvas.tostring_rgb())
+    graphIMG.save(buffer, 'PNG')
+    pylab.close()
+    return HttpResponse(buffer.getvalue(), mimetype='img/png')

--- a/harvardcards/apps/flash/views/stats_graph.py
+++ b/harvardcards/apps/flash/views/stats_graph.py
@@ -21,14 +21,22 @@ import numpy as np
 
 @user_passes_test(lambda u: u.is_superuser or u.is_staff)
 def graph_collections(request):
-    objects =  Users_Collections.objects.all().values()
+    objects = Users_Collections.objects.all().values()
     objects = map(lambda o: o['user_id'], objects)
     users = map(lambda u: u['id'], User.objects.all().values('id'))
     x = map(lambda u: objects.count(u), users)
-    hist(x)
+    figure(facecolor='#f3f3f1')
+    ax = gca()
+    ax.patch.set_facecolor('#f5f5f5')
+    n, bins, patches = hist(x, facecolor='#A51C30', alpha=0.75)
+    print bins
+    ylim((0, max(n)+4))
     xlabel('Number of Collections')
     ylabel('Number of Users')
     title('Histogram of Number of Collections Associated with Users')
+    tick_params(axis="both", which="both", bottom="on", top="off",pad=5,
+                    labelbottom="on", left="on", right="off", labelleft="on", direction='out')
+
     buffer = StringIO.StringIO()
     canvas = pylab.get_current_fig_manager().canvas
     canvas.draw()
@@ -36,3 +44,8 @@ def graph_collections(request):
     graphIMG.save(buffer, 'PNG')
     pylab.close()
     return HttpResponse(buffer.getvalue(), mimetype='img/png')
+
+
+@user_passes_test(lambda u: u.is_superuser or u.is_staff)
+def graphs(request):
+    return render(request, 'stats_graphs.html')

--- a/harvardcards/apps/flash/views/stats_graph.py
+++ b/harvardcards/apps/flash/views/stats_graph.py
@@ -32,7 +32,7 @@ def graph_collections(request):
     ylim((0, max(n)+4))
     xlabel('Number of Collections')
     ylabel('Number of Users')
-    title('Histogram of Number of Collections Associated with Users')
+    title('Histogram of Number of Collections Viewed by Users')
     tick_params(axis="both", which="both", bottom="on", top="off",pad=5,
                     labelbottom="on", left="on", right="off", labelleft="on", direction='out')
 

--- a/harvardcards/apps/flash/views/stats_graph.py
+++ b/harvardcards/apps/flash/views/stats_graph.py
@@ -33,7 +33,7 @@ def initialize_graph():
 def graph_collections(request):
     objects = Users_Collections.objects.all().values()
     objects = map(lambda o: o['user_id'], objects)
-    users = map(lambda u: u['id'], User.objects.all().values('id'))
+    users = User.objects.all().values_list('id', flat=True)
     x = map(lambda u: objects.count(u), users)
 
 
@@ -52,7 +52,7 @@ def graph_collections(request):
 
 @user_passes_test(lambda u: u.is_superuser or u.is_staff)
 def graph_users(request):
-    regs =  map(lambda u: u['date_joined'], User.objects.all().values('date_joined'))
+    regs =  User.objects.all().values_list('date_joined', flat=True)
     min_date, max_date = min(regs).date(), max(regs).date()
     num_days = (max_date - min_date).days + 1
     date_list = [min_date + datetime.timedelta(days=x) for x in range(0, num_days)]

--- a/harvardcards/apps/flash/views/stats_graph.py
+++ b/harvardcards/apps/flash/views/stats_graph.py
@@ -1,20 +1,9 @@
 from django.http import HttpResponse
-from django.template import RequestContext, loader
-from django.views.decorators.http import require_http_methods
-from django.shortcuts import render, redirect
-from django.core.context_processors import csrf
-from django.forms import widgets
-
-from harvardcards.apps.flash.models import Collection, Deck, Card, Decks_Cards, Users_Collections, User
-from harvardcards.apps.flash.forms import DeckImportForm
-from harvardcards.apps.flash.decorators import check_role
-from harvardcards.apps.flash.lti_service import LTIService
-from harvardcards.apps.flash import services, queries, analytics
+from django.shortcuts import render
 from django.contrib.auth.decorators import user_passes_test
 
-import PIL
-import PIL.Image
-import StringIO
+from harvardcards.apps.flash.models import Collection, Users_Collections, User
+
 from matplotlib import pylab
 from pylab import *
 from matplotlib.backends.backend_agg import FigureCanvasAgg as FigureCanvas

--- a/harvardcards/apps/flash/views/stats_graph.py
+++ b/harvardcards/apps/flash/views/stats_graph.py
@@ -29,7 +29,6 @@ def graph_collections(request):
     ax = gca()
     ax.patch.set_facecolor('#f5f5f5')
     n, bins, patches = hist(x, facecolor='#A51C30', alpha=0.75)
-    print bins
     ylim((0, max(n)+4))
     xlabel('Number of Collections')
     ylabel('Number of Users')
@@ -40,7 +39,7 @@ def graph_collections(request):
     buffer = StringIO.StringIO()
     canvas = pylab.get_current_fig_manager().canvas
     canvas.draw()
-    graphIMG = PIL.Image.fromstring('RGB', canvas.get_width_height(), canvas.tostring_rgb())
+    graphIMG = PIL.Image.frombytes('RGB', canvas.get_width_height(), canvas.tostring_rgb())
     graphIMG.save(buffer, 'PNG')
     pylab.close()
     return HttpResponse(buffer.getvalue(), mimetype='img/png')

--- a/harvardcards/static/css/styles.css
+++ b/harvardcards/static/css/styles.css
@@ -754,7 +754,9 @@ div.deckNav{
 	margin-right:auto;
 	display:block;
 }
-
+.graph {
+	padding: .5% .5% .5% .5%;
+}
 /*full card (start) */
 #singleCardHolder, #cardForm{
 	width: 94.5%;

--- a/harvardcards/static/css/styles.css
+++ b/harvardcards/static/css/styles.css
@@ -745,6 +745,15 @@ div.deckNav{
 			height: 106px;
 			width: 40px;
 		}*/
+#graphHolder{
+	border: solid 1px #eae9e8;
+	background: #f3f3f1;
+}
+#graphHolder img{
+	margin-left:auto;
+	margin-right:auto;
+	display:block;
+}
 
 /*full card (start) */
 #singleCardHolder, #cardForm{

--- a/harvardcards/templates/stats_graphs.html
+++ b/harvardcards/templates/stats_graphs.html
@@ -2,11 +2,21 @@
 
 {% block main_content %}
 <div id="content" data-module="">
-    <div class="courseHeader">
-        <h3>Monitoring User Experience</h3>
+    <div class="graph">
+        <div class="courseHeader">
+            <h3>User Experience</h3>
+        </div>
+        <div id="graphHolder">
+            <img src='{% url "graph_collections" %}'/>
+        </div>
     </div>
-    <div id="graphHolder">
-        <img src='{% url "graph_collections" %}'/>
+    <div class="graph">
+        <div class="courseHeader">
+            <h3>Registrations</h3>
+        </div>
+        <div id="graphHolder">
+            <img src='{% url "graph_users" %}'/>
+        </div>
     </div>
 </div>
 {% endblock %}

--- a/harvardcards/templates/stats_graphs.html
+++ b/harvardcards/templates/stats_graphs.html
@@ -1,0 +1,12 @@
+{% extends "__layout_left_sidebar.html" %}
+
+{% block main_content %}
+<div id="content" data-module="">
+    <div class="courseHeader">
+        <h3>Monitoring User Experience</h3>
+    </div>
+    <div id="graphHolder">
+        <img src='{% url "graph_collections" %}'/>
+    </div>
+</div>
+{% endblock %}

--- a/harvardcards/urls.py
+++ b/harvardcards/urls.py
@@ -10,6 +10,8 @@ admin.autodiscover()
 
 urlpatterns = patterns('',
     url(r'graph_collections/$', 'harvardcards.apps.flash.views.stats_graph.graph_collections', name='graph_collections'),
+    url(r'graph_users/$', 'harvardcards.apps.flash.views.stats_graph.graph_users', name='graph_users'),
+
     url(r'stats_graphs$', 'harvardcards.apps.flash.views.stats_graph.graphs', name='stats_graphs'),
 
     #url(r'^$', 'harvardcards.apps.flash.views.site.splash', name='splash'),

--- a/harvardcards/urls.py
+++ b/harvardcards/urls.py
@@ -9,7 +9,8 @@ from django.contrib import admin
 admin.autodiscover()
 
 urlpatterns = patterns('',
-    url(r'stats_graphs/$', 'harvardcards.apps.flash.views.stats_graph.graph_collections', name='stats_graphs'),
+    url(r'graph_collections/$', 'harvardcards.apps.flash.views.stats_graph.graph_collections', name='graph_collections'),
+    url(r'stats_graphs$', 'harvardcards.apps.flash.views.stats_graph.graphs', name='stats_graphs'),
 
     #url(r'^$', 'harvardcards.apps.flash.views.site.splash', name='splash'),
     url(r'^$', 'harvardcards.apps.flash.views.collection.index', name='index'),

--- a/harvardcards/urls.py
+++ b/harvardcards/urls.py
@@ -9,6 +9,8 @@ from django.contrib import admin
 admin.autodiscover()
 
 urlpatterns = patterns('',
+    url(r'stats_graphs/$', 'harvardcards.apps.flash.views.stats_graph.graph_collections', name='stats_graphs'),
+
     #url(r'^$', 'harvardcards.apps.flash.views.site.splash', name='splash'),
     url(r'^$', 'harvardcards.apps.flash.views.collection.index', name='index'),
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,8 +26,8 @@ django-debug-toolbar==0.11
 
 # For image manipulation
 Pillow==2.2.1
-matplotlib==1.3.0
-numpy==1.7.1
+matplotlib==1.3.1
+
 
 # For audio manipulation
 mutagen==1.25.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,6 +26,8 @@ django-debug-toolbar==0.11
 
 # For image manipulation
 Pillow==2.2.1
+matplotlib==1.3.0
+numpy==1.7.1
 
 # For audio manipulation
 mutagen==1.25.1


### PR DESCRIPTION
This PR implements the functionality to:
1) show the number of collections viewed by each user in the admin interface. 
Usage: Go to admin and click Users

2) display plots for different performance metrics (number of collections per user, number of registered users).
Usage: (site address)/stats_graphs

---
[FLASH-226](https://jira.huit.harvard.edu/browse/FLASH-226)