### PR TITLE
feature/heroku-fix-ssl

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn harvardcards.wsgi
+web: gunicorn --config=gunicorn.conf harvardcards.wsgi

--- a/gunicorn.conf
+++ b/gunicorn.conf
@@ -1,0 +1,6 @@
+forwarded_allow_ips = '*'
+secure_scheme_headers = {
+	'X-FORWARDED-PROTOCOL': 'ssl',
+	'X-FORWARDED-PROTO': 'https',
+	'X-FORWARDED-SSL': 'on'
+}

--- a/harvardcards/settings/common.py
+++ b/harvardcards/settings/common.py
@@ -200,6 +200,8 @@ LOGGING = {
     }
 }
 
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+
 # This dictionary defines application-level feature toggles. 
 # Usage:
 #       from django.conf import settings


### PR DESCRIPTION
Updated the gunicorn and django configuration to identify secure requests using the X-Forwarded-Proto header.