### PR TITLE
Refactored model and code to copy collections more efficiently

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,5 @@ before_script:
 # command(s) to run tests
 script: 
     - python manage.py syncdb --noinput
-#    - python manage.py migrate --noinput
+    - python manage.py migrate --noinput
     - nosetests

--- a/harvardcards/apps/flash/migrations/0009_auto__add_field_card_clone_ref_id__add_field_decks_cards_clone_ref_id_.py
+++ b/harvardcards/apps/flash/migrations/0009_auto__add_field_card_clone_ref_id__add_field_decks_cards_clone_ref_id_.py
@@ -1,0 +1,220 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'Card.clone_ref_id'
+        db.add_column(u'flash_card', 'clone_ref_id',
+                      self.gf('django.db.models.fields.CharField')(max_length=50, null=True),
+                      keep_default=False)
+
+        # Adding field 'Decks_Cards.clone_ref_id'
+        db.add_column(u'flash_decks_cards', 'clone_ref_id',
+                      self.gf('django.db.models.fields.CharField')(max_length=50, null=True),
+                      keep_default=False)
+
+        # Adding field 'Cards_Fields.clone_ref_id'
+        db.add_column(u'flash_cards_fields', 'clone_ref_id',
+                      self.gf('django.db.models.fields.CharField')(max_length=50, null=True),
+                      keep_default=False)
+
+        # Adding field 'Deck.clone_ref_id'
+        db.add_column(u'flash_deck', 'clone_ref_id',
+                      self.gf('django.db.models.fields.CharField')(max_length=50, null=True),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'Card.clone_ref_id'
+        db.delete_column(u'flash_card', 'clone_ref_id')
+
+        # Deleting field 'Decks_Cards.clone_ref_id'
+        db.delete_column(u'flash_decks_cards', 'clone_ref_id')
+
+        # Deleting field 'Cards_Fields.clone_ref_id'
+        db.delete_column(u'flash_cards_fields', 'clone_ref_id')
+
+        # Deleting field 'Deck.clone_ref_id'
+        db.delete_column(u'flash_deck', 'clone_ref_id')
+
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'flash.analytics': {
+            'Meta': {'ordering': "['-stmt_stored', 'stmt_actor_user', 'stmt_actor_desc', 'stmt_verb', 'stmt_object']", 'object_name': 'Analytics'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'stmt_actor_desc': ('django.db.models.fields.CharField', [], {'max_length': '4000'}),
+            'stmt_actor_user': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']", 'null': 'True'}),
+            'stmt_context': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'stmt_id': ('django.db.models.fields.CharField', [], {'max_length': '36'}),
+            'stmt_json': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'stmt_object': ('django.db.models.fields.CharField', [], {'max_length': '4000'}),
+            'stmt_stored': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'stmt_timestamp': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'stmt_verb': ('django.db.models.fields.CharField', [], {'max_length': '4000'})
+        },
+        u'flash.card': {
+            'Meta': {'object_name': 'Card'},
+            'clone_ref_id': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True'}),
+            'collection': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['flash.Collection']"}),
+            'color': ('django.db.models.fields.CharField', [], {'default': "'default'", 'max_length': '12'}),
+            'fields': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['flash.Field']", 'through': u"orm['flash.Cards_Fields']", 'symmetrical': 'False'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'sort_order': ('django.db.models.fields.IntegerField', [], {'default': '1'})
+        },
+        u'flash.cards_fields': {
+            'Meta': {'ordering': "['field__sort_order']", 'object_name': 'Cards_Fields'},
+            'card': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['flash.Card']"}),
+            'clone_ref_id': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True'}),
+            'field': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['flash.Field']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'value': ('django.db.models.fields.CharField', [], {'max_length': '500'})
+        },
+        u'flash.cardtemplate': {
+            'Meta': {'object_name': 'CardTemplate'},
+            'description': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'fields': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['flash.Field']", 'through': u"orm['flash.CardTemplates_Fields']", 'symmetrical': 'False'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']", 'null': 'True', 'blank': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '200'})
+        },
+        u'flash.cardtemplates_fields': {
+            'Meta': {'ordering': "['field__sort_order']", 'object_name': 'CardTemplates_Fields'},
+            'card_template': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['flash.CardTemplate']"}),
+            'field': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['flash.Field']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        u'flash.clone': {
+            'Meta': {'ordering': "['-clone_date', 'model', 'model_id', 'cloned_by']", 'object_name': 'Clone'},
+            'clone_date': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'cloned_by': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '48'}),
+            'model_id': ('django.db.models.fields.CharField', [], {'max_length': '24'}),
+            'status': ('django.db.models.fields.CharField', [], {'max_length': '1'})
+        },
+        u'flash.cloned': {
+            'Meta': {'ordering': "['-clone', 'model', 'old_model_id', 'new_model_id']", 'object_name': 'Cloned'},
+            'clone': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['flash.Clone']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '48'}),
+            'new_model_id': ('django.db.models.fields.CharField', [], {'max_length': '24'}),
+            'old_model_id': ('django.db.models.fields.CharField', [], {'max_length': '24'})
+        },
+        u'flash.collection': {
+            'Meta': {'object_name': 'Collection'},
+            'card_template': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['flash.CardTemplate']"}),
+            'description': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'published': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'users': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.User']", 'through': u"orm['flash.Users_Collections']", 'symmetrical': 'False'})
+        },
+        u'flash.course': {
+            'Meta': {'ordering': "['course_id', 'course_name_short', 'course_name']", 'object_name': 'Course'},
+            'canvas_course_id': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'context_id': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'course_id': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255'}),
+            'course_name': ('django.db.models.fields.CharField', [], {'max_length': '2048'}),
+            'course_name_short': ('django.db.models.fields.CharField', [], {'max_length': '1024'}),
+            'entity': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'product': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'})
+        },
+        u'flash.course_map': {
+            'Meta': {'ordering': "['course', 'collection__id', 'subscribe']", 'object_name': 'Course_Map'},
+            'collection': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['flash.Collection']"}),
+            'course': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['flash.Course']"}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'subscribe': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        },
+        u'flash.deck': {
+            'Meta': {'ordering': "['sort_order', 'title']", 'object_name': 'Deck'},
+            'cards': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['flash.Card']", 'through': u"orm['flash.Decks_Cards']", 'symmetrical': 'False'}),
+            'clone_ref_id': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True'}),
+            'collection': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['flash.Collection']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'sort_order': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '200'})
+        },
+        u'flash.decks_cards': {
+            'Meta': {'ordering': "['sort_order']", 'object_name': 'Decks_Cards'},
+            'card': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['flash.Card']"}),
+            'clone_ref_id': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True'}),
+            'deck': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['flash.Deck']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'sort_order': ('django.db.models.fields.IntegerField', [], {'default': '1'})
+        },
+        u'flash.field': {
+            'Meta': {'ordering': "['sort_order']", 'object_name': 'Field'},
+            'display': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'example_value': ('django.db.models.fields.CharField', [], {'max_length': '500', 'blank': 'True'}),
+            'field_type': ('django.db.models.fields.CharField', [], {'max_length': '1'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'label': ('django.db.models.fields.CharField', [], {'max_length': '200', 'blank': 'True'}),
+            'show_label': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'sort_order': ('django.db.models.fields.IntegerField', [], {'default': '1'})
+        },
+        u'flash.mediastore': {
+            'Meta': {'ordering': "['file_name']", 'object_name': 'MediaStore'},
+            'file_md5hash': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'file_name': ('django.db.models.fields.CharField', [], {'max_length': '1024'}),
+            'file_size': ('django.db.models.fields.PositiveIntegerField', [], {}),
+            'file_type': ('django.db.models.fields.CharField', [], {'max_length': '127'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'reference_count': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'store_created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'store_updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'})
+        },
+        u'flash.users_collections': {
+            'Meta': {'object_name': 'Users_Collections'},
+            'collection': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['flash.Collection']"}),
+            'date_joined': ('django.db.models.fields.DateField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'role': ('django.db.models.fields.CharField', [], {'default': "'O'", 'max_length': '1'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']"})
+        }
+    }
+
+    complete_apps = ['flash']

--- a/harvardcards/apps/flash/models.py
+++ b/harvardcards/apps/flash/models.py
@@ -77,6 +77,7 @@ class Card(models.Model):
     sort_order = models.IntegerField(default=1)
     fields = models.ManyToManyField(Field, through='Cards_Fields')
     color = models.CharField(max_length=12, choices=COLOR_CHOICES, default=DEFAULT_COLOR)
+    clone_ref_id = models.CharField(max_length=50, null=True)
 
     def __unicode__(self):
         return "Card: " + str(self.id) + "; Collection: " + str(self.collection.title)
@@ -86,6 +87,7 @@ class Deck(models.Model):
     collection = models.ForeignKey(Collection)
     cards = models.ManyToManyField(Card, through='Decks_Cards')
     sort_order = models.IntegerField(default=1)
+    clone_ref_id = models.CharField(max_length=50, null=True)
 
     class Meta:
         verbose_name = 'Deck'
@@ -109,6 +111,7 @@ class Decks_Cards(models.Model):
     deck = models.ForeignKey(Deck)
     card = models.ForeignKey(Card)
     sort_order = models.IntegerField(default=1)
+    clone_ref_id = models.CharField(max_length=50, null=True)
 
     class Meta:
         verbose_name = 'Deck Cards'
@@ -122,6 +125,7 @@ class Cards_Fields(models.Model):
     card = models.ForeignKey(Card)
     field = models.ForeignKey(Field)
     value = models.CharField(max_length=500)
+    clone_ref_id = models.CharField(max_length=50, null=True)
 
     class Meta:
         verbose_name = 'Card Fields'

--- a/harvardcards/settings/common.py
+++ b/harvardcards/settings/common.py
@@ -146,7 +146,7 @@ INSTALLED_APPS = [
     # 'django.contrib.admindocs',
     'harvardcards.apps.flash',
     #'harvardcards.apps.jasmine',
-    #'south'
+    'south'
 ]
 
 FIXTURE_DIRS = (


### PR DESCRIPTION
This PR optimizes the copying process so that the number of database transactions are a constant  number regardless of the size of the collection. 

Before, the number of database transactions scaled linearly with the size of the collection (number of decks, cards, and fields), meaning that large collections could take a long time to copy. On Heroku, this was taking too long (>30 seconds) for one particularly large collection, and Heorku was timing out after 30 seconds, killing the process. This PR should fix that problem.

A few technical notes:

* The ```bulk_create``` method is used to batch create models, but one of the downsides of this method, is that the IDs of the newly created models are not returned. 
* There is a migration that adds a new column to some models: ```clone_ref_id```. This column is used to lookup the model records that have been bulk created. The column may be null orl hold a value like ```<clone_id>:<sequence_number>```, which uniquely identifies the model within the context of that cloning process. Without this, it isn't possible to map the new models to the old models, which is recorded in the ```Cloned``` model for auditing purposes.

@jazahn review?