### PR TITLE
feature/confirm-collection-delete

### DIFF
--- a/harvardcards/static/js/modules/collections-index.js
+++ b/harvardcards/static/js/modules/collections-index.js
@@ -1,4 +1,4 @@
-define(['jquery','views/CollectionListView','views/CollectionCreateModal', 'views/DeckCreateModal'], function($,CollectionListView, CollectionCreateModal, DeckCreateModal) {
+define(['jquery','views/CollectionListView','views/CollectionCreateModal', 'views/DeckCreateModal', 'utils/utils'], function($,CollectionListView, CollectionCreateModal, DeckCreateModal, utils) {
     document.getElementById('collection_type').onchange = function(){
         var currentVal = this.value;
         if (currentVal == 2){
@@ -44,6 +44,7 @@ define(['jquery','views/CollectionListView','views/CollectionCreateModal', 'view
                 deck_modals[i].init();
             }
 
+			utils.setupConfirm();
 		}
 	};
 });


### PR DESCRIPTION
Added confirmation step when deleting a collection on the index screen. The ```collections-index.js``` module was missing a call to ```utils.setupConfirm();``` which scans the page for **data-confirm** attributes and automatically adds a confirmation dialog to those elements. 

Fixes https://github.com/Harvard-ATG/HarvardCards/issues/151

@jazahn review?

---
[FLASH-277](https://jira.huit.harvard.edu/browse/FLASH-277)