### PR TITLE
feature/refactor-course-vs-private-collections

### DIFF
--- a/harvardcards/apps/flash/queries.py
+++ b/harvardcards/apps/flash/queries.py
@@ -41,15 +41,22 @@ def groupCollectionsByList(collection_list):
     """groups collections into 'course' vs 'private' collections"""
 
     group_of = {
-        "size": 0,
+        "num_collections": 0,
         "course": {
-            "size": 0,
+            "label": "Course Collections",
             "collections": [],
+            "num_collections": 0,
+            "num_published": 0,
+            "num_unpublished": 0,
         },
         "private": {
-            "size": 0,
+            "label": "Private Collections",
             "collections": [],
+            "num_collections": 0,
+            "num_published": 0,
+            "num_unpublished": 0,
         },
+        "groups": []
     }
     
     course_collection_map = {}
@@ -61,12 +68,21 @@ def groupCollectionsByList(collection_list):
 
     for collection in collection_list:
         if collection['id'] in course_collection_map:
-            bucket = 'course'
+            group_key = 'course'
         else:
-            bucket = 'private'
-        group_of[bucket]['collections'].append(collection)
-        group_of[bucket]['size'] += 1
-        group_of['size'] += 1
+            group_key = 'private'
+
+        if collection['published']:
+            publish_key = 'num_published'
+        else:
+            publish_key = 'num_unpublished'
+
+        group_of[group_key]['collections'].append(collection)
+        group_of[group_key]['num_collections'] += 1
+        group_of[group_key][publish_key] += 1
+        group_of['num_collections'] += 1
+        
+    group_of['groups'] = [group_of['course'], group_of['private']]
     
     return group_of
 

--- a/harvardcards/apps/flash/queries.py
+++ b/harvardcards/apps/flash/queries.py
@@ -116,6 +116,11 @@ def getCollectionList(role_bucket, **kwargs):
     for collection in collections:
         has_access = has_role_in_bucket(role_bucket, collection_roles, collection.id)
         log.debug("collection id: [%s] has access: [%s]" % (collection.id, has_access))
+
+        if collection.id in role_bucket[Users_Collections.role_map[Users_Collections.LEARNER]]:
+            has_access = has_access and collection.published
+            log.debug("checking access based on whether collection is published: %s" % has_access)
+        
         if has_access:
             collection_decks = []
             log.debug("decks for collection id [%s]: %s" % (collection.id, decks_by_collection.get(collection.id, None)))

--- a/harvardcards/apps/flash/views/collection.py
+++ b/harvardcards/apps/flash/views/collection.py
@@ -226,8 +226,7 @@ def toggle_publish(request, collection_id=None):
     collection = Collection.objects.get(id=collection_id)
     collection.published = not collection.published
     collection.save()
-    return redirect(collection)
-
+    return redirect('collectionIndex')
 
 
 @login_required

--- a/harvardcards/apps/flash/views/collection.py
+++ b/harvardcards/apps/flash/views/collection.py
@@ -33,7 +33,7 @@ def index(request, collection_id=None):
     lti_req = LTIService(request)
     course_collections = lti_req.getCourseCollections()
 
-    is_teacher = lti_req.isTeacher()
+    is_teacher = lti_req.isTeacher() or queries.is_superuser_or_staff(request.user)
 
     copy_collections = queries.getCopyCollectionList(request.user)
     collection_filters = dict(collection_ids=course_collections, can_filter=not queries.is_superuser_or_staff(request.user))

--- a/harvardcards/apps/flash/views/collection.py
+++ b/harvardcards/apps/flash/views/collection.py
@@ -29,13 +29,6 @@ def index(request, collection_id=None):
     if collection_id is not None:
         collection_id = int(collection_id)
 
-    def add_all_card_deck(collection):
-        decks = collection['decks']
-        num_cards = sum(map(lambda d: d['num_cards'], decks))
-        if num_cards:
-            collection['decks'] = [{'title': 'All Cards', 'id':-collection['id'], 'num_cards': num_cards}] + collection['decks']
-        return collection
-
     role_bucket = services.get_or_update_role_bucket(request)
     lti_req = LTIService(request)
     course_collections = lti_req.getCourseCollections()
@@ -45,28 +38,15 @@ def index(request, collection_id=None):
     copy_collections = queries.getCopyCollectionList(request.user)
     collection_filters = dict(collection_ids=course_collections, can_filter=not queries.is_superuser_or_staff(request.user))
     collection_list = queries.getCollectionList(role_bucket, **collection_filters)
-    collection_list = map(lambda c: add_all_card_deck(c), collection_list)
-
-    active_collection = None
-    display_collections = collection_list
-    display_collections_1 = {'Private': [], 'Public': []}
-    course_ids = queries.get_course_collection_ids()
-    for collection in display_collections:
-        id = collection['id']
-        published = collection['published']
-        if id in course_ids and published:
-            display_collections_1['Public'].append(collection)
-        else:
-            display_collections_1['Private'].append(collection)
+    display_collections = queries.groupCollectionsByList(collection_list)
 
     context = {
         "nav_collections": collection_list,
-        "display_collections": display_collections_1,
+        "display_collections": display_collections,
         "copy_collections": copy_collections,
-        "active_collection": active_collection,
+        "active_collection": None,
         "user_collection_role": role_bucket,
         "is_teacher": is_teacher,
-        "collection_id": collection_id
     }
 
     if collection_id:
@@ -74,12 +54,10 @@ def index(request, collection_id=None):
             cur_collection = Collection.objects.get(id=collection_id)
         except Collection.DoesNotExist:
             raise Http404
-        display_collections = [c for c in collection_list if c['id'] == cur_collection.id]
-        if len(display_collections) == 0:
+        filtered_collection_list = [c for c in collection_list if c['id'] == cur_collection.id]
+        if len(filtered_collection_list) == 0:
             raise Http404
-        else:
-            active_collection = display_collections[0]
-        context['display_collections'] = display_collections
+        context['active_collection'] = filtered_collection_list[0]
 
     analytics.track(
         actor=request.user,

--- a/harvardcards/static/css/styles.css
+++ b/harvardcards/static/css/styles.css
@@ -375,6 +375,12 @@ ul.addACourseContent div {
     cursor: pointer;
     background-color: lightgrey;
 }
+.courseHeaderPublished {
+	background-color: lightgrey !important;
+}
+.courseHeaderUnpublished {
+	background-color: darkgray !important;
+}
 .courseHeaderClickable > .plusminus,
 .courseHeaderClickable > .adminMenuRight {
     margin-left: .5em;

--- a/harvardcards/static/js/modules/module-loader.js
+++ b/harvardcards/static/js/modules/module-loader.js
@@ -1,4 +1,4 @@
-define(['jquery', 'lodash', 'mixins/debug-mixin'], function($, _, DebugMixin) {
+define(['jquery', 'jqueryui', 'lodash', 'mixins/debug-mixin'], function($, $ui, _, DebugMixin) {
 
 	/**
 	 * The ModuleLoader is responsible for finding and loading modules
@@ -84,6 +84,7 @@ define(['jquery', 'lodash', 'mixins/debug-mixin'], function($, _, DebugMixin) {
 			var loader = new ModuleLoader(rootEl);
 			loader.loadAll();
 		});
+		$(document).tooltip();
 	};
 
 	return ModuleLoader;

--- a/harvardcards/static/js/views/CollectionListView.js
+++ b/harvardcards/static/js/views/CollectionListView.js
@@ -27,6 +27,10 @@ define(['jquery'], function($) {
                 self.togglePlusMinusCls(el);
             });
 
+            
+            // Commenting this out because it's resulting in weird/unpredictable behavior
+            // in conjunction with the template logic for hiding/showing collecitons.
+            /*
             this.getHeaderEls().each(function(index, el) {
                 var collection_id = $(el).data('collection-id');
                 var collection_state = localStorage.getItem('show-collection-id'+collection_id);
@@ -37,6 +41,7 @@ define(['jquery'], function($) {
                     self.toggleCollapse(el, false);
                 }
             });
+            */
 
             self.initialized = true;
         },

--- a/harvardcards/templates/_collection_nav.html
+++ b/harvardcards/templates/_collection_nav.html
@@ -1,3 +1,4 @@
+{% comment %}
 <!-- unsure if this should be left in for the OS version -->
 <!--
 <div id="navigation">
@@ -31,3 +32,4 @@
     </nav>
 </div>
 -->
+{% endcomment %}

--- a/harvardcards/templates/_collection_view.html
+++ b/harvardcards/templates/_collection_view.html
@@ -8,14 +8,14 @@
         <ul class="adminMenu adminMenuRight">
             {% if is_teacher %}
             <li>
-                <a class="adminMenuBtn hidden-mobile" href="{% url 'collectionPublish' collection.id %}?collection_id={{collection.id}}"><i class="fa fa-upload"></i>
-                {% if collection.published %} Unpublish {% else %} Publish {% endif %}
+                <a class="adminMenuBtn hidden-mobile" href="{% url 'collectionPublish' collection.id %}?collection_id={{collection.id}}" title="{% if collection.published %}Unpublish{% else %}Publish{% endif %} Collection">
+                {% if collection.published %}<i class="fa fa-check-circle"></i> Published{% else %}<i class="fa fa-exclamation-circle"></i> Not Published{% endif %}
                 </a>
             </li>
             {% endif %}
 
-            <li><a class="adminMenuBtn hidden-mobile" href="{% url 'collectionEdit' collection.id %}?collection_id={{collection.id}}"><i class="fa fa-pencil"></i> Edit</a></li>
-            <li><a class="adminMenuBtn hidden-mobile" href="{% url 'collectionDelete' collection.id %}?collection_id={{collection.id}}" data-confirm="Are you sure you want to delete: {{collection.title|escape}}?"><i class="fa fa-times-circle"></i> Delete</a></li>
+            <li><a class="adminMenuBtn hidden-mobile" href="{% url 'collectionEdit' collection.id %}?collection_id={{collection.id}}" title="Edit Collection"><i class="fa fa-pencil"></i> Edit</a></li>
+            <li><a class="adminMenuBtn hidden-mobile" href="{% url 'collectionDelete' collection.id %}?collection_id={{collection.id}}" data-confirm="Are you sure you want to delete: {{collection.title|escape}}?" title="Delete Collection"><i class="fa fa-times-circle"></i> Delete</a></li>
             <!-- <li><a class="adminMenuBtn hidden-mobile" href="{% url 'collectionShare' collection.id %}?collection_id={{collection.id}}"><i class="fa fa-share"></i> Share</a></li> -->
         </ul>
     {% endif %}

--- a/harvardcards/templates/_collection_view.html
+++ b/harvardcards/templates/_collection_view.html
@@ -1,4 +1,4 @@
-<div class="courseHeader courseHeaderClickable" data-collection-id="{{ collection.id }}">
+<div class="courseHeader courseHeaderClickable {% if collection.published %}courseHeaderPublished{% else %}courseHeaderUnpublished{% endif %}" data-collection-id="{{ collection.id }}">
     <i class="plusminus fa {% if current_collection_id == collection.id %}fa-minus-circle{% else %}fa-plus-circle{% endif %} fa-lg"></i>
     {% spaceless %}
         <h2 class="courseTitle">{{ collection.title }}</h2>
@@ -9,7 +9,7 @@
             {% if is_teacher %}
             <li>
                 <a class="adminMenuBtn hidden-mobile" href="{% url 'collectionPublish' collection.id %}?collection_id={{collection.id}}" title="{% if collection.published %}Unpublish{% else %}Publish{% endif %} Collection">
-                {% if collection.published %}<i class="fa fa-check-circle"></i> Published{% else %}<i class="fa fa-exclamation-circle"></i> Not Published{% endif %}
+                {% if collection.published %}<i class="fa fa-cloud-download"></i> Unpublish{% else %}<i class="fa fa-cloud-upload"></i> Publish{% endif %}
                 </a>
             </li>
             {% endif %}

--- a/harvardcards/templates/_collection_view.html
+++ b/harvardcards/templates/_collection_view.html
@@ -1,5 +1,5 @@
 <div class="courseHeader courseHeaderClickable" data-collection-id="{{ collection.id }}">
-    <i class="plusminus fa fa-plus-circle fa-lg"></i>
+    <i class="plusminus fa {% if current_collection_id == collection.id %}fa-minus-circle{% else %}fa-plus-circle{% endif %} fa-lg"></i>
     {% spaceless %}
         <h2 class="courseTitle">{{ collection.title }}</h2>
         <h3>{% if collection.decks|length == 1 %}1 Deck{% else %}{{collection.decks|length}} Decks{% endif %}</h3>
@@ -20,7 +20,7 @@
         </ul>
     {% endif %}
 </div>
-<div class="courseBody {% if collection_id != collection.id %} hide {% endif %}">
+<div class="courseBody {% if current_collection_id != collection.id %}hide{% endif %}">
     {% if collection.id in user_collection_role.ADMINISTRATOR %}
     <div class="deck add hidden-mobile">
         <a href="{% url 'collectionAddDeck' collection.id %}?collection_id={{collection.id}}" id="addDeck-{{collection.id}}">Add a Deck</a>

--- a/harvardcards/templates/collections/index.html
+++ b/harvardcards/templates/collections/index.html
@@ -13,6 +13,7 @@
 {% block main_content %}
 <div id="content" data-module="collections-index">
     {% if not active_collection %}
+		{% comment %}Only show  the "Add Collection" on the index screen{% endcomment %}
         {% if user.is_authenticated %}
             <div class="hidden-mobile">
                 <a href="{% url 'collectionCreate' %}" id="addAcourse">Add Collection</a>
@@ -20,7 +21,7 @@
         {% endif %}
     {% endif %}
 
-    {% if display_collections|length > 0 %}
+    {% if display_collections.size > 0 %}
         <ul class="adminMenu adminMenuRight">
             <li>
                 <div class="form-input">
@@ -40,37 +41,42 @@
             </li>
         </ul>
         <div class="clear"></div>
-        {% if display_collections|length > 1 %}
-        <div id="course_coll">
-            <div class="courseHeader"><h3>Course Collections</h3></div>
-            <ul class="accordion" style="margin-top: .5em">
-            {% for collection in display_collections.Public %}
-                <li>
-                {% include "_collection_view.html" with collection=collection user_collection_role=user_collection_role current_collection_id=collection_id %}
-                </li>
-            {% endfor %}
-            </ul>
-        </div>
-        <div id="private_coll">
-            <div class="courseHeader"><h3>Private Collections</h3></div>
-            <ul class="accordion" style="margin-top: .5em">
-            {% for collection in display_collections.Private %}
-                <li>
-                {% include "_collection_view.html" with is_teacher=is_teacher collection=collection user_collection_role=user_collection_role current_collection_id=collection_id %}
-                </li>
-            {% endfor %}
-            </ul>
-        </div>
-
-        {% else %}
-        <ul class="accordion" style="margin-top: .5em">
-            <li>
-            {% include "_collection_view.html" with is_teacher=is_teacher collection=display_collections.0 user_collection_role=user_collection_role current_collection_id=collection_id %}
-            </li>
-        </ul>
-        {% endif %}
-
-    {% endif %}
+		
+		{% if active_collection %}
+			<div id="course_coll">
+				<ul class="accordion" style="margin-top: .5em">
+					<li>
+					{% include "_collection_view.html" with is_teacher=is_teacher collection=active_collection user_collection_role=user_collection_role current_collection_id=active_collection.id %}
+					</li>
+				</ul>
+			</div>
+		{% else %}
+	
+			<div id="course_coll">
+				<div class="courseHeader"><h3>Course Collections ({{display_collections.course.size}})</h3></div>
+				<ul class="accordion" style="margin-top: .5em">
+				{% for collection in display_collections.course.collections %}
+					<li>
+					{% include "_collection_view.html" with is_teacher=is_teacher collection=collection user_collection_role=user_collection_role current_collection_id=active_collection.id %}
+					</li>
+				{% endfor %}
+				</ul>
+			</div>
+	
+			<div id="private_coll">
+				<div class="courseHeader"><h3>Private Collections ({{display_collections.private.size}})</h3></div>
+				<ul class="accordion" style="margin-top: .5em">
+				{% for collection in display_collections.private.collections %}
+					<li>
+					{% include "_collection_view.html" with is_teacher=is_teacher collection=collection user_collection_role=user_collection_role current_collection_id=active_collection.id %}
+					</li>
+				{% endfor %}
+				</ul>
+			</div>
+		{% endif %}
+	{% else%}
+		<div>No collections to display.</div>
+	{% endif %}
 </div>
 
 <div id="addAcourseDialog" style="display:none" title="Add Collection">

--- a/harvardcards/templates/collections/index.html
+++ b/harvardcards/templates/collections/index.html
@@ -21,7 +21,9 @@
         {% endif %}
     {% endif %}
 
-    {% if display_collections.num_collections > 0 %}
+    {% if display_collections.num_collections == 0 %}
+        <h2 style="margin: 1em 0;">No collections to display</h2>
+    {% else %}
         <ul class="adminMenu adminMenuRight">
             <li>
                 <div class="form-input">
@@ -41,42 +43,39 @@
             </li>
         </ul>
         <div class="clear"></div>
-		
-		{% if active_collection %}
-			<div id="course_coll">
-				<ul class="accordion" style="margin-top: .5em">
-					<li>
-					{% include "_collection_view.html" with is_teacher=is_teacher collection=active_collection user_collection_role=user_collection_role current_collection_id=active_collection.id %}
-					</li>
-				</ul>
-			</div>
-		{% else %}
-			{% for display_group in display_collections.groups %}
-				<div id="course_coll">
-					<div class="courseHeader"><h3>{{display_group.label}} ({{display_group.num_collections}})</h3></div>
-					{% for group in display_group.groups %}
-						{% if group.name != "" %}
-							<h2>{{ group.name }}</h2>
-						{% endif %}
-						{% if is_teacher and group.num_collections > 0%}
-							<div>
-								<i title="Published collections to make them available">Published: {{group.num_published}}</i>&nbsp;<i title="Unpublished collections to make them unavailable">Unpublished: {{group.num_unpublished}}</i>
-							</div>
-						{% endif %}
-						<ul class="accordion" style="margin-top: .5em">
-							{% for collection in group.collections %}
-							<li>
-							{% include "_collection_view.html" with is_teacher=is_teacher collection=collection user_collection_role=user_collection_role current_collection_id=active_collection.id %}
-							</li>
-							{% endfor %}
-						</ul>
-					{% endfor %}
-				</div>			
-			{% endfor %}
-		{% endif %}
-	{% else%}
-		<h2 style="margin: 1em 0;">No collections to display</h2>
-	{% endif %}
+        {% if active_collection %}
+            <div id="course_coll">
+                <ul class="accordion" style="margin-top: .5em">
+                    <li>
+                    {% include "_collection_view.html" with is_teacher=is_teacher collection=active_collection user_collection_role=user_collection_role current_collection_id=active_collection.id %}
+                    </li>
+                </ul>
+            </div>
+        {% else %}
+            {% for display_group in display_collections.groups %}
+            <div id="course_coll">
+                <div class="courseHeader"><h3>{{display_group.label}} ({{display_group.num_collections}})</h3></div>
+                {% for group in display_group.groups %}
+                    {% if group.name != "" %}
+                        <h2>{{ group.name }}</h2>
+                    {% endif %}
+
+                    {% if is_teacher and group.num_collections > 0%}
+                    <div>
+                        <i title="Published collections to make them available">Published: {{group.num_published}}</i>&nbsp;<i title="Unpublished collections to make them unavailable">Unpublished: {{group.num_unpublished}}</i>
+                    </div>
+                    {% endif %}
+
+                    <ul class="accordion" style="margin-top: .5em">
+                    {% for collection in group.collections %}
+                        <li>{% include "_collection_view.html" with is_teacher=is_teacher collection=collection user_collection_role=user_collection_role current_collection_id=active_collection.id %}</li>
+                    {% endfor %}
+                    </ul>
+                {% endfor %}
+            </div>
+            {% endfor %}
+        {% endif %}
+    {% endif %}
 </div>
 
 <div id="addAcourseDialog" style="display:none" title="Add Collection">

--- a/harvardcards/templates/collections/index.html
+++ b/harvardcards/templates/collections/index.html
@@ -21,7 +21,7 @@
         {% endif %}
     {% endif %}
 
-    {% if display_collections.size > 0 %}
+    {% if display_collections.num_collections > 0 %}
         <ul class="adminMenu adminMenuRight">
             <li>
                 <div class="form-input">
@@ -51,28 +51,21 @@
 				</ul>
 			</div>
 		{% else %}
-	
-			<div id="course_coll">
-				<div class="courseHeader"><h3>Course Collections ({{display_collections.course.size}})</h3></div>
-				<ul class="accordion" style="margin-top: .5em">
-				{% for collection in display_collections.course.collections %}
-					<li>
-					{% include "_collection_view.html" with is_teacher=is_teacher collection=collection user_collection_role=user_collection_role current_collection_id=active_collection.id %}
-					</li>
-				{% endfor %}
-				</ul>
-			</div>
-	
-			<div id="private_coll">
-				<div class="courseHeader"><h3>Private Collections ({{display_collections.private.size}})</h3></div>
-				<ul class="accordion" style="margin-top: .5em">
-				{% for collection in display_collections.private.collections %}
-					<li>
-					{% include "_collection_view.html" with is_teacher=is_teacher collection=collection user_collection_role=user_collection_role current_collection_id=active_collection.id %}
-					</li>
-				{% endfor %}
-				</ul>
-			</div>
+			{% for display_group in display_collections.groups %}
+				<div id="course_coll">
+					<div class="courseHeader"><h3>{{display_group.label}} ({{display_group.num_collections}})</h3></div>
+					{% if is_teacher %}
+						<div>There are {{display_group.num_published}} published collections and {{display_group.num_unpublished}} unpublished collections.</div>
+					{% endif %}
+					<ul class="accordion" style="margin-top: .5em">
+					{% for collection in display_group.collections %}
+						<li>
+						{% include "_collection_view.html" with is_teacher=is_teacher collection=collection user_collection_role=user_collection_role current_collection_id=active_collection.id %}
+						</li>
+					{% endfor %}
+					</ul>
+				</div>			
+			{% endfor %}
 		{% endif %}
 	{% else%}
 		<div>No collections to display.</div>

--- a/harvardcards/templates/collections/index.html
+++ b/harvardcards/templates/collections/index.html
@@ -54,21 +54,28 @@
 			{% for display_group in display_collections.groups %}
 				<div id="course_coll">
 					<div class="courseHeader"><h3>{{display_group.label}} ({{display_group.num_collections}})</h3></div>
-					{% if is_teacher %}
-						<div>There are {{display_group.num_published}} published collections and {{display_group.num_unpublished}} unpublished collections.</div>
-					{% endif %}
-					<ul class="accordion" style="margin-top: .5em">
-					{% for collection in display_group.collections %}
-						<li>
-						{% include "_collection_view.html" with is_teacher=is_teacher collection=collection user_collection_role=user_collection_role current_collection_id=active_collection.id %}
-						</li>
+					{% for group in display_group.groups %}
+						{% if group.name != "" %}
+							<h2>{{ group.name }}</h2>
+						{% endif %}
+						{% if is_teacher and group.num_collections > 0%}
+							<div>
+								<i title="Published collections to make them available">Published: {{group.num_published}}</i>&nbsp;<i title="Unpublished collections to make them unavailable">Unpublished: {{group.num_unpublished}}</i>
+							</div>
+						{% endif %}
+						<ul class="accordion" style="margin-top: .5em">
+							{% for collection in group.collections %}
+							<li>
+							{% include "_collection_view.html" with is_teacher=is_teacher collection=collection user_collection_role=user_collection_role current_collection_id=active_collection.id %}
+							</li>
+							{% endfor %}
+						</ul>
 					{% endfor %}
-					</ul>
 				</div>			
 			{% endfor %}
 		{% endif %}
 	{% else%}
-		<div>No collections to display.</div>
+		<h2 style="margin: 1em 0;">No collections to display</h2>
 	{% endif %}
 </div>
 


### PR DESCRIPTION
Refactoring the display logic on the course index.

- *Course Collections*: collections that are associated with a course in Canvas.
- *Private collections*: collections **not** associated with any course in Canvas.
- Within each group, collections are either *published* or *unpublished*. Published collections are visible and accessible learners. Unpublished collections are neither visible nor accessible to learners.

Prior to this change, publishing a collection moved the collection from "private" to "course" collections, but that behavior was confusing. That doesn't happen anymore. Now, publishing and unpublishing merely controls the visibility of the collection to subscribed learners, such as students in the course.

See screenshot:
![screen shot 2015-10-05 at 12 41 48 pm](https://cloud.githubusercontent.com/assets/1165361/10286949/7da3e2c8-6b5e-11e5-8780-9f1d488de07d.png)

@jazahn review?

---
[FLASH-286](https://jira.huit.harvard.edu/browse/FLASH-286) and https://github.com/Harvard-ATG/HarvardCards/issues/161