### PR TITLE
bugfix/audioplayback

### DIFF
--- a/static/js/components/slider/DeckSlider.js
+++ b/static/js/components/slider/DeckSlider.js
@@ -287,21 +287,21 @@ define(['jquery', 'microevent', 'components/slider/Slider'], function($, MicroEv
     }
 
 	// Plays the slider (i.e. auto-advance to the next card).
-	DeckSlider.prototype.play = function(doneCallback) {
-		this._playIntervalId = window.setInterval(this._play(doneCallback), this.playbackDelay);
+	DeckSlider.prototype.play = function(onNextCallback, doneCallback, delay) {
+		var playbackDelay = delay || this.playbackDelay;
+		this._playIntervalId = window.setInterval(this._play(onNextCallback, doneCallback), playbackDelay);
 	};
 
 	// Helper method (private) to play the slider.
-	DeckSlider.prototype._play = function(doneCallback) {
+	DeckSlider.prototype._play = function(onNextCallback, doneCallback) {
 		return $.proxy(function() {
 			var isNext = this.goToNext();
-            // forcing a click to have something easy to listen for
-            $(this.currentCardEl).click();
 			var pause = !isNext || this.isLastItem();
+			onNextCallback();
 			if(pause) {
 				this.pause();
 				doneCallback();
-			}
+			} 
 		}, this);
 	};
 

--- a/static/js/modules/deck-view.js
+++ b/static/js/modules/deck-view.js
@@ -47,9 +47,6 @@ function initModule() {
 
 		$controls.removeClass("card-active").hide();
 		//$card.removeClass('card-active').hide();
-
-		deck_slider._slideDirection = (data.toIndex >= data.fromIndex ? "right" : "left");
-		deck_slider._slideCurrent = (data.toIndex == data.fromIndex);
 	});
 
     deck_slider.bind("slide", function(slider, data) {
@@ -58,11 +55,6 @@ function initModule() {
 		var $card = $cardDetail.find(".card[data-card-id="+card_id+"]");
 		var playAudio = MODULE.makeAudioPlayer($card);
 		var mode = $card.data("mode");
-
-		var slideOpts = {
-			direction: deck_slider._slideDirection,
-			complete: playAudio
-		};
 
         // send tracking
 		Analytics.trackCard(card_id, mode);
@@ -74,12 +66,8 @@ function initModule() {
 		// show the card
 		$card.addClass('card-active');
 
-
-        if(deck_slider._slideCurrent) {
-			$card.show();
-			playAudio();
-		}
-
+		$card.show();
+		playAudio();
     });
 
     /* Swiper */
@@ -210,7 +198,9 @@ function initModule() {
 	    var pauseText = 'Pause';
 	    if ($("#play_cards .control-text").text() == playText){
 			deck_slider.play(function() {
-				$("#play_cards").click();
+				mySwiper.slideNext();
+			}, function() {
+				$("#play_cards").click(); // done!
 			});
 	        $("#play_cards .control-text").text(pauseText);
 			$("#play").removeClass('fa-play').addClass('fa-pause');


### PR DESCRIPTION
This PR fixes #175. 

The issue was faulty logic for determining whether to play the audio on a flashcard. The logic was meant to check if the user was advancing to a "new" card or not, and only play the audio if it was in fact a new card, but in reality it was only playing the audio if the user was advancing to the same card (i.e. clicked on the same card). The faulty logic worked in autoplay mode because when the slider advanced to the next card, it triggered a duplicate event on the same card so that the *Swiper* would detect the change, but the unintended side effect was that the slider also picked up the event and simply advanced to the same card, causing the audio to be played. When the user manually advanced, the audio would not play.

The fix was to simply remove that faulty logic and fix the duplicate event that was being triggered unnecessarily. The result is that the audio should now automatically  play when the user advances the deck manually, or if it is advanced via playback mode.